### PR TITLE
/VNW and /void

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -24,8 +24,8 @@ exports.MUTED_PREFIX = '[white](muted)';
 exports.bannedWords = (function (words) {
     return words.map(function (word) { return (typeof word == "string" || word instanceof RegExp) ? [word, []] : [word[0], word.slice(1)]; });
 })([
-    "uwu",
-    "nig" + "ger", "nig" + "ga", "niger", "ni8" + "8ger",
+    "uwu", //lol
+    "nig" + "ger", "nig" + "ga", "niger", "ni8" + "8ger", //our apologies to citizens of the Republic of Niger
     "re" + "tard",
     'kill yourself', 'kill urself', /\bkys\b/,
     /\bkill blacks\b/,
@@ -179,7 +179,7 @@ exports.tips = {
         "All commands with a player as an argument support using a menu to specify the player. Just run the command leaving the argument blank, and a menu will show up.",
         "Players with a ".concat(ranks_1.Rank.trusted.prefix, " in front of their name aren't staff members, but they do have extra powers."),
         "Staff members will have the following prefixes in front of their name: ".concat(ranks_1.Rank.manager.prefix, ", ").concat(ranks_1.Rank.admin.prefix, ", ").concat(ranks_1.Rank.mod.prefix),
-        "wave cooldown to long? skip the wait with /VSW"
+        "Wave cooldown too long? Skip the wait with /vnw"
     ],
     staff: []
 };

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -178,7 +178,8 @@ exports.tips = {
         "Want to send the phrase [white]\"/command\"[] in chat? Type [white]\"./command\"[] and the [white].[] will be removed.",
         "All commands with a player as an argument support using a menu to specify the player. Just run the command leaving the argument blank, and a menu will show up.",
         "Players with a ".concat(ranks_1.Rank.trusted.prefix, " in front of their name aren't staff members, but they do have extra powers."),
-        "Staff members will have the following prefixes in front of their name: ".concat(ranks_1.Rank.manager.prefix, ", ").concat(ranks_1.Rank.admin.prefix, ", ").concat(ranks_1.Rank.mod.prefix)
+        "Staff members will have the following prefixes in front of their name: ".concat(ranks_1.Rank.manager.prefix, ", ").concat(ranks_1.Rank.admin.prefix, ", ").concat(ranks_1.Rank.mod.prefix),
+        "wave cooldown to long? skip the wait with /VSW"
     ],
     staff: []
 };

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -16,11 +16,13 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.stopAntiEvadeTime = exports.heuristics = exports.rules = exports.tips = exports.maxTime = exports.localDebug = exports.Mode = exports.getGamemode = exports.FishServers = exports.ip = exports.multiCharSubstitutions = exports.substitutions = exports.adminNames = exports.bannedInNamesWords = exports.strictBannedWords = exports.bannedWords = exports.MUTED_PREFIX = exports.MARKED_PREFIX = void 0;
+exports.stopAntiEvadeTime = exports.heuristics = exports.rules = exports.tips = exports.maxTime = exports.localDebug = exports.Mode = exports.getGamemode = exports.FishServers = exports.ip = exports.multiCharSubstitutions = exports.substitutions = exports.adminNames = exports.bannedInNamesWords = exports.strictBannedWords = exports.bannedWords = exports.TIME_TILL_NOT_NEW = exports.JOINS_TILL_NOT_NEW = exports.MUTED_PREFIX = exports.MARKED_PREFIX = void 0;
 var globals_1 = require("./globals"); //TODO fix storage of global variables
 var ranks_1 = require("./ranks");
 exports.MARKED_PREFIX = '[yellow]\u26A0[scarlet]Marked Griefer[]\u26A0[]';
 exports.MUTED_PREFIX = '[white](muted)';
+exports.JOINS_TILL_NOT_NEW = 25;
+exports.TIME_TILL_NOT_NEW = 1 * 60 * 60 * 1000;
 exports.bannedWords = (function (words) {
     return words.map(function (word) { return (typeof word == "string" || word instanceof RegExp) ? [word, []] : [word[0], word.slice(1)]; });
 })([

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -165,7 +165,7 @@ export const tips = {
 		`All commands with a player as an argument support using a menu to specify the player. Just run the command leaving the argument blank, and a menu will show up.`,
 		`Players with a ${Rank.trusted.prefix} in front of their name aren't staff members, but they do have extra powers.`,
 		`Staff members will have the following prefixes in front of their name: ${Rank.manager.prefix}, ${Rank.admin.prefix}, ${Rank.mod.prefix}`,
-		`wave cooldown to long? skip the wait with /VSW`
+		`Wave cooldown too long? Skip the wait with /vnw`
 	],
 	staff: [
 

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -164,7 +164,8 @@ export const tips = {
 		`Want to send the phrase [white]"/command"[] in chat? Type [white]"./command"[] and the [white].[] will be removed.`,
 		`All commands with a player as an argument support using a menu to specify the player. Just run the command leaving the argument blank, and a menu will show up.`,
 		`Players with a ${Rank.trusted.prefix} in front of their name aren't staff members, but they do have extra powers.`,
-		`Staff members will have the following prefixes in front of their name: ${Rank.manager.prefix}, ${Rank.admin.prefix}, ${Rank.mod.prefix}`
+		`Staff members will have the following prefixes in front of their name: ${Rank.manager.prefix}, ${Rank.admin.prefix}, ${Rank.mod.prefix}`,
+		`wave cooldown to long? skip the wait with /VSW`
 	],
 	staff: [
 

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -3,6 +3,8 @@ import { Rank } from "./ranks";
 
 export const MARKED_PREFIX = '[yellow]\u26A0[scarlet]Marked Griefer[]\u26A0[]';
 export const MUTED_PREFIX = '[white](muted)';
+export const JOINS_TILL_NOT_NEW = 25;
+export const TIME_TILL_NOT_NEW = 1 * 60 * 60 * 1000;
 export const bannedWords:[word:string | RegExp, whitelist:string[]][] = (
 	(words:(string | string[] | RegExp)[]) =>
 		words.map(word => (typeof word == "string" || word instanceof RegExp) ? [word, []] : [word[0], word.slice(1)])

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -505,8 +505,8 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
         },
     }, void: {
         args: [],
-        description: '',
-        perm: commands_1.Perm.fromRank(ranks_1.Rank.trusted),
+        description: 'sends a reminder in chat power voids',
+        perm: commands_1.Perm.fromRank(ranks_1.Rank.trusted), // Im allowing trusted to do this, but with a 10s cooldown to prevent spam.
         handler: function (_a) {
             var lastUsedSuccessfullySender = _a.lastUsedSuccessfullySender;
             if (Date.now() - lastUsedSuccessfullySender < 10000)

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -546,7 +546,61 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
                 (0, utils_1.neutralGameover)();
             }
         }
-    }, rtv: (0, commands_1.command)(function () {
+    }, forcevnw: {
+        args: ["force:boolean?"],
+        description: 'Force skip to the next map.',
+        perm: commands_1.Perm.admin,
+        handler: function (_a) {
+            var args = _a.args, sender = _a.sender, allCommands = _a.allCommands;
+            if (args.force === false) {
+                Call.sendMessage("VNW: [red] votes cleared by admin [yellow]".concat(sender.name, "[red]."));
+                allCommands.vnw.data.votes.clear();
+            }
+            else {
+                //todo, skip wave
+            }
+        }
+    }, nvw: (0, commands_1.command)(function () {
+        var votes = new Set();
+        var ratio = 0.25;
+        Events.on(EventType.PlayerLeave, function (_a) {
+            var player = _a.player;
+            if (votes.has(player.uuid())) {
+                votes.delete(player.uuid());
+                var currentVotes = votes.size;
+                var requiredVotes = Math.ceil(ratio * Groups.player.size());
+                Call.sendMessage("VNW: [accent]".concat(player.name, "[] left, [green]").concat(currentVotes, "[] votes, [green]").concat(requiredVotes, "[] required"));
+                if (currentVotes >= requiredVotes) {
+                    Call.sendMessage('VNW: [green] vote passed, skipping to next wave');
+                    //todo, skip wave shit
+                }
+            }
+        });
+        Events.on(EventType.GameOverEvent, function () { return votes.clear(); });
+        return {
+            args: [],
+            description: 'Vote to start next wave',
+            perm: commands_1.Perm.play,
+            data: { votes: votes },
+            handler: function (_a) {
+                var sender = _a.sender, lastUsedSuccessfullySender = _a.lastUsedSuccessfullySender;
+                if (!config_1.Mode.survival())
+                    (0, commands_1.fail)("you can only skip waves on survival");
+                if (Vars.state.gameOver)
+                    (0, commands_1.fail)("This game is already over");
+                if (Date.now() - lastUsedSuccessfullySender < 1000)
+                    (0, commands_1.fail)("This command was run recently and is on cooldown.");
+                votes.add(sender.uuid);
+                var currentVotes = votes.size;
+                var requiredVotes = Math.ceil(ratio * Groups.player.size());
+                Call.sendMessage("RTV: [accent]".concat(sender.cleanedName, "[] wants to skip this wave, [green]").concat(currentVotes, "[] votes, [green]").concat(requiredVotes, "[] required"));
+                if (currentVotes >= requiredVotes) {
+                    Call.sendMessage('RTV: [green] vote passed, skipping to next wave.');
+                    //idk do some skip wave shit here
+                }
+            }
+        };
+    }), rtv: (0, commands_1.command)(function () {
         var votes = new Set();
         var ratio = 0.5;
         Events.on(EventType.PlayerLeave, function (_a) {

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -511,7 +511,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
             var lastUsedSuccessfullySender = _a.lastUsedSuccessfullySender;
             if (Date.now() - lastUsedSuccessfullySender < 10000)
                 (0, commands_1.fail)("command on cooldown, please wait");
-            Call.sendMessage("[white]Power Voids (\uF83F) are commonly used to create traps that trigger once they are destroyed. Please avoid destroying them for the sake of your teamates");
+            Call.sendMessage("[white]Power Voids (\uF83F) are commonly used to create traps that trigger once they are destroyed. Please avoid destroying them for the sake of your teammates");
         },
     }, team: {
         args: ['team:team', 'target:player?'],

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -508,7 +508,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
         description: '',
         perm: commands_1.Perm.fromRank(ranks_1.Rank.trusted),
         handler: function (_a) {
-            var outputFail = _a.outputFail, outputSuccess = _a.outputSuccess, lastUsedSuccessfullySender = _a.lastUsedSuccessfullySender;
+            var lastUsedSuccessfullySender = _a.lastUsedSuccessfullySender;
             if (Date.now() - lastUsedSuccessfullySender < 10000)
                 (0, commands_1.fail)("command on cooldown, please wait");
             Call.sendMessage("[white]Power Voids (\uF83F) are commonly used to create traps that trigger once they are destroyed. Please avoid destroying them for the sake of your teamates");

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -503,6 +503,16 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
             if (target !== sender)
                 outputSuccess(f(templateObject_5 || (templateObject_5 = __makeTemplateObject(["Reminded ", " of the rules."], ["Reminded ", " of the rules."])), target));
         },
+    }, void: {
+        args: [],
+        description: '',
+        perm: commands_1.Perm.fromRank(ranks_1.Rank.trusted),
+        handler: function (_a) {
+            var outputFail = _a.outputFail, outputSuccess = _a.outputSuccess, lastUsedSuccessfullySender = _a.lastUsedSuccessfullySender;
+            if (Date.now() - lastUsedSuccessfullySender < 10000)
+                (0, commands_1.fail)("command on cooldown, please wait");
+            Call.sendMessage("[white]Power Voids (\uF83F) are commonly used to create traps that trigger once they are destroyed. Please avoid destroying them for the sake of your teamates");
+        },
     }, team: {
         args: ['team:team', 'target:player?'],
         description: 'Changes the team of a player.',
@@ -557,12 +567,15 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
                 allCommands.vnw.data.votes.clear();
             }
             else {
-                //todo, skip wave
+                var oldTime_1 = Vars.state.wavetime;
+                Vars.state.wavetime = 1;
+                Core.app.post(function () { Core.app.post(function () { Vars.state.wavetime = oldTime_1; }); });
+                Call.sendMessage("VNW [yellow]".concat(sender.name, "[red] Has forced the next wave to start"));
             }
         }
-    }, nvw: (0, commands_1.command)(function () {
+    }, vnw: (0, commands_1.command)(function () {
         var votes = new Set();
-        var ratio = 0.25;
+        var ratio = 0.33; //It takes 1/2 for rtv, and that is always a slog, i figured 1/3 vote shows cooperation, but not 
         Events.on(EventType.PlayerLeave, function (_a) {
             var player = _a.player;
             if (votes.has(player.uuid())) {
@@ -571,8 +584,10 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
                 var requiredVotes = Math.ceil(ratio * Groups.player.size());
                 Call.sendMessage("VNW: [accent]".concat(player.name, "[] left, [green]").concat(currentVotes, "[] votes, [green]").concat(requiredVotes, "[] required"));
                 if (currentVotes >= requiredVotes) {
+                    var oldTime_2 = Vars.state.wavetime;
+                    Vars.state.wavetime = 1;
+                    Core.app.post(function () { Core.app.post(function () { Vars.state.wavetime = oldTime_2; }); });
                     Call.sendMessage('VNW: [green] vote passed, skipping to next wave');
-                    //todo, skip wave shit
                 }
             }
         });
@@ -595,8 +610,10 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
                 var requiredVotes = Math.ceil(ratio * Groups.player.size());
                 Call.sendMessage("RTV: [accent]".concat(sender.cleanedName, "[] wants to skip this wave, [green]").concat(currentVotes, "[] votes, [green]").concat(requiredVotes, "[] required"));
                 if (currentVotes >= requiredVotes) {
-                    Call.sendMessage('RTV: [green] vote passed, skipping to next wave.');
-                    //idk do some skip wave shit here
+                    var oldTime_3 = Vars.state.wavetime;
+                    Vars.state.wavetime = 1;
+                    Core.app.post(function () { Core.app.post(function () { Vars.state.wavetime = oldTime_3; }); });
+                    Call.sendMessage('VNW: [green] vote passed, skipping to next wave');
                 }
             }
         };

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -586,7 +586,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
                 if (currentVotes >= requiredVotes) {
                     var oldTime_2 = Vars.state.wavetime;
                     Vars.state.wavetime = 1;
-                    Core.app.post(function () { Core.app.post(function () { Vars.state.wavetime = oldTime_2; }); }); // a bastard of a line of code, but it works
+                    Core.app.post(function () { Core.app.post(function () { Vars.state.wavetime = oldTime_2; }); });
                     Call.sendMessage('VNW: [green] vote passed, skipping to next wave');
                 }
             }
@@ -603,12 +603,12 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
                     (0, commands_1.fail)("you can only skip waves on survival");
                 if (Vars.state.gameOver)
                     (0, commands_1.fail)("This game is already over");
-                if (Date.now() - lastUsedSuccessfullySender < 1000)
+                if (Date.now() - lastUsedSuccessfullySender < 10000)
                     (0, commands_1.fail)("This command was run recently and is on cooldown.");
                 votes.add(sender.uuid);
                 var currentVotes = votes.size;
                 var requiredVotes = Math.ceil(ratio * Groups.player.size());
-                Call.sendMessage("RTV: [accent]".concat(sender.cleanedName, "[] wants to skip this wave, [green]").concat(currentVotes, "[] votes, [green]").concat(requiredVotes, "[] required"));
+                Call.sendMessage("VNW: [accent]".concat(sender.cleanedName, "[] wants to skip this wave, [green]").concat(currentVotes, "[] votes, [green]").concat(requiredVotes, "[] required"));
                 if (currentVotes >= requiredVotes) {
                     var oldTime_3 = Vars.state.wavetime;
                     Vars.state.wavetime = 1;

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -586,7 +586,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
                 if (currentVotes >= requiredVotes) {
                     var oldTime_2 = Vars.state.wavetime;
                     Vars.state.wavetime = 1;
-                    Core.app.post(function () { Core.app.post(function () { Vars.state.wavetime = oldTime_2; }); });
+                    Core.app.post(function () { Core.app.post(function () { Vars.state.wavetime = oldTime_2; }); }); // a bastard of a line of code, but it works
                     Call.sendMessage('VNW: [green] vote passed, skipping to next wave');
                 }
             }

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -559,7 +559,7 @@ Available types:[yellow]
 				if(currentVotes >= requiredVotes){
 					let oldTime = Vars.state.wavetime;
 					Vars.state.wavetime = 1;
-					Core.app.post(() => {Core.app.post(() => {Vars.state.wavetime = oldTime;})});
+					Core.app.post(() => {Core.app.post(() => {Vars.state.wavetime = oldTime;})}); // a bastard of a line of code, but it works
 					Call.sendMessage('VNW: [green] vote passed, skipping to next wave');
 				}
 			}

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -481,7 +481,7 @@ Available types:[yellow]
 		args: [],
 		description: '',
 		perm: Perm.fromRank(Rank.trusted),
-		handler({outputFail,outputSuccess,lastUsedSuccessfullySender}){
+		handler({lastUsedSuccessfullySender}){
 			if(Date.now() - lastUsedSuccessfullySender < 10000) fail(`command on cooldown, please wait`);
 			Call.sendMessage(`[white]Power Voids () are commonly used to create traps that trigger once they are destroyed. Please avoid destroying them for the sake of your teamates`);
 		},

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -517,6 +517,65 @@ Available types:[yellow]
 			}
 		}
 	},
+	
+	forcevnw: { // will work on all servers for testing / trol purposes
+		args: ["force:boolean?"],
+		description: 'Force skip to the next map.',
+		perm: Perm.admin,
+		handler({args, sender, allCommands}){
+			if(args.force === false){
+				Call.sendMessage(`VNW: [red] votes cleared by admin [yellow]${sender.name}[red].`);
+				allCommands.vnw.data.votes.clear();
+			} else {
+				//todo, skip wave
+			}
+		}
+	},
+	nvw: command(() => { // only works on survival
+		const votes = new Set<string>();
+		const ratio = 0.25;
+
+		Events.on(EventType.PlayerLeave, ({player}) => {
+			if(votes.has(player.uuid())){
+				votes.delete(player.uuid());
+				const currentVotes = votes.size;
+				const requiredVotes = Math.ceil(ratio * Groups.player.size());
+				Call.sendMessage(
+					`VNW: [accent]${player.name}[] left, [green]${currentVotes}[] votes, [green]${requiredVotes}[] required`
+				);
+				if(currentVotes >= requiredVotes){
+					Call.sendMessage('VNW: [green] vote passed, skipping to next wave');
+
+					//todo, skip wave shit
+				}
+			}
+		});		
+		Events.on(EventType.GameOverEvent, () => votes.clear());
+
+		return {
+			args: [],
+			description: 'Vote to start next wave',
+			perm: Perm.play,
+			data: {votes},
+			handler({sender, lastUsedSuccessfullySender}){
+				if(!Mode.survival()) fail(`you can only skip waves on survival`);
+				if(Vars.state.gameOver) fail(`This game is already over`);
+				if(Date.now() - lastUsedSuccessfullySender < 1000) fail(`This command was run recently and is on cooldown.`);
+				votes.add(sender.uuid);
+				let currentVotes = votes.size;
+				let requiredVotes = Math.ceil(ratio * Groups.player.size());
+				Call.sendMessage(
+					`RTV: [accent]${sender.cleanedName}[] wants to skip this wave, [green]${currentVotes}[] votes, [green]${requiredVotes}[] required`
+				);
+				if(currentVotes >= requiredVotes){
+					Call.sendMessage('RTV: [green] vote passed, skipping to next wave.');
+					
+					//idk do some skip wave shit here
+
+				}
+			}
+		}	
+	}),
 
 	rtv: command(() => {
 		const votes = new Set<string>();

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -477,6 +477,16 @@ Available types:[yellow]
 		},
 	},
 
+	void: {
+		args: [],
+		description: '',
+		perm: Perm.fromRank(Rank.trusted),
+		handler({outputFail,outputSuccess,lastUsedSuccessfullySender}){
+			if(Date.now() - lastUsedSuccessfullySender < 10000) fail(`command on cooldown, please wait`);
+			Call.sendMessage(`[white]Power Voids () are commonly used to create traps that trigger once they are destroyed. Please avoid destroying them for the sake of your teamates`);
+		},
+	},
+
 	team: {
 		args: ['team:team', 'target:player?'],
 		description: 'Changes the team of a player.',
@@ -527,13 +537,16 @@ Available types:[yellow]
 				Call.sendMessage(`VNW: [red] votes cleared by admin [yellow]${sender.name}[red].`);
 				allCommands.vnw.data.votes.clear();
 			} else {
-				//todo, skip wave
+				let oldTime = Vars.state.wavetime;
+				Vars.state.wavetime = 1;
+				Core.app.post(() => {Core.app.post(() => {Vars.state.wavetime = oldTime;})});
+				Call.sendMessage(`VNW [yellow]${sender.name}[red] Has forced the next wave to start`);
 			}
 		}
 	},
-	nvw: command(() => { // only works on survival
+	vnw: command(() => { // only works on survival
 		const votes = new Set<string>();
-		const ratio = 0.25;
+		const ratio = 0.33;//It takes 1/2 for rtv, and that is always a slog, i figured 1/3 vote shows cooperation, but not 
 
 		Events.on(EventType.PlayerLeave, ({player}) => {
 			if(votes.has(player.uuid())){
@@ -544,9 +557,10 @@ Available types:[yellow]
 					`VNW: [accent]${player.name}[] left, [green]${currentVotes}[] votes, [green]${requiredVotes}[] required`
 				);
 				if(currentVotes >= requiredVotes){
+					let oldTime = Vars.state.wavetime;
+					Vars.state.wavetime = 1;
+					Core.app.post(() => {Core.app.post(() => {Vars.state.wavetime = oldTime;})});
 					Call.sendMessage('VNW: [green] vote passed, skipping to next wave');
-
-					//todo, skip wave shit
 				}
 			}
 		});		
@@ -568,10 +582,10 @@ Available types:[yellow]
 					`RTV: [accent]${sender.cleanedName}[] wants to skip this wave, [green]${currentVotes}[] votes, [green]${requiredVotes}[] required`
 				);
 				if(currentVotes >= requiredVotes){
-					Call.sendMessage('RTV: [green] vote passed, skipping to next wave.');
-					
-					//idk do some skip wave shit here
-
+					let oldTime = Vars.state.wavetime;
+					Vars.state.wavetime = 1;
+					Core.app.post(() => {Core.app.post(() => {Vars.state.wavetime = oldTime;})});
+					Call.sendMessage('VNW: [green] vote passed, skipping to next wave');
 				}
 			}
 		}	

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -544,7 +544,7 @@ Available types:[yellow]
 			}
 		}
 	},
-	vnw: command(() => { // only works on survival
+	vnw: command(() => {
 		const votes = new Set<string>();
 		const ratio = 0.33;//It takes 1/2 for rtv, and that is always a slog, i figured 1/3 vote shows cooperation, but not 
 
@@ -559,7 +559,7 @@ Available types:[yellow]
 				if(currentVotes >= requiredVotes){
 					let oldTime = Vars.state.wavetime;
 					Vars.state.wavetime = 1;
-					Core.app.post(() => {Core.app.post(() => {Vars.state.wavetime = oldTime;})}); // a bastard of a line of code, but it works
+					Core.app.post(() => {Core.app.post(() => {Vars.state.wavetime = oldTime;})});
 					Call.sendMessage('VNW: [green] vote passed, skipping to next wave');
 				}
 			}
@@ -574,12 +574,12 @@ Available types:[yellow]
 			handler({sender, lastUsedSuccessfullySender}){
 				if(!Mode.survival()) fail(`you can only skip waves on survival`);
 				if(Vars.state.gameOver) fail(`This game is already over`);
-				if(Date.now() - lastUsedSuccessfullySender < 1000) fail(`This command was run recently and is on cooldown.`);
+				if(Date.now() - lastUsedSuccessfullySender < 10000) fail(`This command was run recently and is on cooldown.`);
 				votes.add(sender.uuid);
 				let currentVotes = votes.size;
 				let requiredVotes = Math.ceil(ratio * Groups.player.size());
 				Call.sendMessage(
-					`RTV: [accent]${sender.cleanedName}[] wants to skip this wave, [green]${currentVotes}[] votes, [green]${requiredVotes}[] required`
+					`VNW: [accent]${sender.cleanedName}[] wants to skip this wave, [green]${currentVotes}[] votes, [green]${requiredVotes}[] required`
 				);
 				if(currentVotes >= requiredVotes){
 					let oldTime = Vars.state.wavetime;

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -479,8 +479,8 @@ Available types:[yellow]
 
 	void: {
 		args: [],
-		description: '',
-		perm: Perm.fromRank(Rank.trusted),
+		description: 'sends a reminder in chat power voids',
+		perm: Perm.fromRank(Rank.trusted),// Im allowing trusted to do this, but with a 10s cooldown to prevent spam.
 		handler({lastUsedSuccessfullySender}){
 			if(Date.now() - lastUsedSuccessfullySender < 10000) fail(`command on cooldown, please wait`);
 			Call.sendMessage(`[white]Power Voids () are commonly used to create traps that trigger once they are destroyed. Please avoid destroying them for the sake of your teamates`);

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -483,7 +483,7 @@ Available types:[yellow]
 		perm: Perm.fromRank(Rank.trusted),// Im allowing trusted to do this, but with a 10s cooldown to prevent spam.
 		handler({lastUsedSuccessfullySender}){
 			if(Date.now() - lastUsedSuccessfullySender < 10000) fail(`command on cooldown, please wait`);
-			Call.sendMessage(`[white]Power Voids () are commonly used to create traps that trigger once they are destroyed. Please avoid destroying them for the sake of your teamates`);
+			Call.sendMessage(`[white]Power Voids () are commonly used to create traps that trigger once they are destroyed. Please avoid destroying them for the sake of your teammates`);
 		},
 	},
 

--- a/scripts/players.js
+++ b/scripts/players.js
@@ -326,6 +326,7 @@ var FishPlayer = /** @class */ (function () {
             fishPlayer.updateAdminStatus();
             fishPlayer.updateMemberExclusiveState();
             fishPlayer.checkVPNAndJoins();
+            fishPlayer.checkNew();
             api.getStopped(player.uuid(), function (unmarkTime) {
                 if (unmarkTime)
                     fishPlayer.unmarkTime = unmarkTime;
@@ -707,6 +708,21 @@ var FishPlayer = /** @class */ (function () {
             var message_1 = showAd ? "[gold]".concat(messageText, "[]") : "[gold]Tip: ".concat(messageText, "[]");
             //Delay sending the message so it doesn't get lost in the spam of messages that usually occurs when you join
             Timer.schedule(function () { return _this.sendMessage(message_1); }, 3);
+        }
+    };
+    FishPlayer.prototype.checkNew = function () {
+        if (this.marked())
+            return;
+        if (this.ranksAtLeast(ranks_1.Rank.trusted))
+            return; //no demoting 
+        if (this.joinsLessThan(config.JOINS_TILL_NOT_NEW) || this.stats.timeInGame < config.TIME_TILL_NOT_NEW) {
+            if (this.rank.level != -1) {
+                this.setRank(ranks_1.Rank.new);
+                return;
+            }
+        }
+        else {
+            this.setRank(ranks_1.Rank.player);
         }
     };
     //#endregion

--- a/scripts/players.ts
+++ b/scripts/players.ts
@@ -299,6 +299,7 @@ export class FishPlayer {
 			fishPlayer.updateAdminStatus();
 			fishPlayer.updateMemberExclusiveState();
 			fishPlayer.checkVPNAndJoins();
+			fishPlayer.checkNew();
 			api.getStopped(player.uuid(), (unmarkTime) => {
 				if(unmarkTime)
 					fishPlayer.unmarkTime = unmarkTime;
@@ -641,6 +642,19 @@ We apologize for the inconvenience.`
 			//Delay sending the message so it doesn't get lost in the spam of messages that usually occurs when you join
 			Timer.schedule(() => this.sendMessage(message), 3);
 		}
+	}
+	checkNew(){
+		if(this.marked()) return; 
+		if(this.ranksAtLeast(Rank.trusted)) return; //no demoting 
+		if(this.joinsLessThan(config.JOINS_TILL_NOT_NEW) ||  this.stats.timeInGame < config.TIME_TILL_NOT_NEW){
+			if(this.rank.level != -1){
+				this.setRank(Rank.new);
+				return;
+			}
+		}else{
+			this.setRank(Rank.player);
+		}
+		
 	}
 	//#endregion
 

--- a/scripts/ranks.js
+++ b/scripts/ranks.js
@@ -23,7 +23,7 @@ var Rank = /** @class */ (function () {
         return this.color + this.name + "[]";
     };
     Rank.ranks = {};
-    Rank.new = new Rank("new", -1, "For new players.", "\uE827", "[N]", "[forest]");
+    Rank.new = new Rank("new", -1, "For new players.", "[orange]\uE827", "[N]", "[forest]");
     Rank.player = new Rank("player", 0, "Ordinary players.", "", "[P]", "");
     Rank.trusted = new Rank("trusted", 2, "Trusted players who have gained the trust of a mod or admin.", "[black]<[#E67E22]\uE813[]>[]", "&y[T]&fr", "[#E67E22]");
     Rank.mod = new Rank("mod", 3, "Moderators who can mute, stop, and kick players.", "[black]<[#6FFC7C]\uE817[]>[]", "&g[M]&fr", "[#6FFC7C]");

--- a/scripts/ranks.js
+++ b/scripts/ranks.js
@@ -23,7 +23,7 @@ var Rank = /** @class */ (function () {
         return this.color + this.name + "[]";
     };
     Rank.ranks = {};
-    Rank.new = new Rank("new", -1, "For new players.", "", "[N]", "[forest]");
+    Rank.new = new Rank("new", -1, "For new players.", "\uE827", "[N]", "[forest]");
     Rank.player = new Rank("player", 0, "Ordinary players.", "", "[P]", "");
     Rank.trusted = new Rank("trusted", 2, "Trusted players who have gained the trust of a mod or admin.", "[black]<[#E67E22]\uE813[]>[]", "&y[T]&fr", "[#E67E22]");
     Rank.mod = new Rank("mod", 3, "Moderators who can mute, stop, and kick players.", "[black]<[#6FFC7C]\uE817[]>[]", "&g[M]&fr", "[#6FFC7C]");

--- a/scripts/ranks.ts
+++ b/scripts/ranks.ts
@@ -3,7 +3,7 @@ import type { SelectClasslikeEnumKeys as SelectEnumClassKeys } from "./types";
 export class Rank {
 	static ranks:Record<string, Rank> = {};
 	
-	static new = new Rank("new", -1, "For new players.", "", "[N]", "[forest]");
+	static new = new Rank("new", -1, "For new players.", "\uE827", "[N]", "[forest]");
 	static player = new Rank("player", 0, "Ordinary players.", "", "[P]", "");
 	static trusted = new Rank("trusted", 2, "Trusted players who have gained the trust of a mod or admin.", "[black]<[#E67E22]\uE813[]>[]", "&y[T]&fr", "[#E67E22]");
 	static mod = new Rank("mod", 3, "Moderators who can mute, stop, and kick players.", "[black]<[#6FFC7C]\uE817[]>[]", "&g[M]&fr", "[#6FFC7C]");

--- a/scripts/ranks.ts
+++ b/scripts/ranks.ts
@@ -3,7 +3,7 @@ import type { SelectClasslikeEnumKeys as SelectEnumClassKeys } from "./types";
 export class Rank {
 	static ranks:Record<string, Rank> = {};
 	
-	static new = new Rank("new", -1, "For new players.", "\uE827", "[N]", "[forest]");
+	static new = new Rank("new", -1, "For new players.", "[orange]\uE827", "[N]", "[forest]");
 	static player = new Rank("player", 0, "Ordinary players.", "", "[P]", "");
 	static trusted = new Rank("trusted", 2, "Trusted players who have gained the trust of a mod or admin.", "[black]<[#E67E22]\uE813[]>[]", "&y[T]&fr", "[#E67E22]");
 	static mod = new Rank("mod", 3, "Moderators who can mute, stop, and kick players.", "[black]<[#6FFC7C]\uE817[]>[]", "&g[M]&fr", "[#6FFC7C]");


### PR DESCRIPTION
I was feeling a little bored, so I added 3 new commands
- /VNW vote-new-wave, starts a RTV-esq vote to skip to wave cool down. requires 1/3 of the server to vote, and is only enabled in survival - I hope this is a replacement for wave skipper tanks.
- /forceVNW allows admins and up to either cancel or auto-pass a /VNW vote. similar to /forceRTV
- /void based on this -> https://discord.com/channels/965438060508631050/1217994758429868133 , it allows trusted and up to, once per 10 seconds, send a formal message in chat defining power voids. (basically a chat macro).

Also added auto-assigning the "new" rank, I have some ideas for what to do with the rank, but they are still very rough