### PR TITLE
add /hexed command

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -120,6 +120,7 @@ exports.FishServers = {
     attack: { name: "attack", ip: "162.248.100.98", port: "6567", aliases: ["attack", "attac", "atack", "atak", "atck", "atk", "a"] },
     survival: { name: "survival", ip: "162.248.101.95", port: "6567", aliases: ["survival", "surviv", "surv", "sur", "su", "s", "sl"] },
     pvp: { name: "pvp", ip: "162.248.100.133", port: "6567", aliases: ["pvp", "pv", "p", "playerversusplayer"] },
+    hexed: { name: "hexed", ip: "162.248.101.53", port: "6567", aliases: ["hexed", "hex", "h", "he"] },
     // sandbox: { ip: "162.248.102.204", port: "6567" },
     byName: function (input) {
         var _a;

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -109,6 +109,7 @@ export const FishServers = {
 	attack: { name: "attack", ip: "162.248.100.98", port: "6567", aliases: ["attack", "attac", "atack", "atak", "atck", "atk", "a"] },
 	survival: { name: "survival", ip: "162.248.101.95", port: "6567", aliases: ["survival", "surviv", "surv", "sur", "su", "s", "sl"] },
 	pvp: { name: "pvp", ip: "162.248.100.133", port: "6567", aliases: ["pvp", "pv", "p", "playerversusplayer"] },
+	hexed: { name: "hexed", ip: "162.248.101.53", port: "6567", aliases: ["hexed", "hex", "h", "he"] },
 	// sandbox: { ip: "162.248.102.204", port: "6567" },
 	byName(input:string):FishServer | null {
 		input = input.toLowerCase();


### PR DESCRIPTION
To fully integrate hexed gamemode, a few more changes will be needed, both plugin side and API..

Currently any request to the api is erroring out and I cant figure out why.. more troubleshooting is needed there. I imagine the main issue is that `Vars.state.rules.mode().name()` for the hexed server is `"pvp"` which conflicts with actual pvp.. we will likely have a similar issue for TD gamemode as well.