### PR TITLE
2 1/2 new commands and a very boring day

### DIFF
--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -102,6 +102,7 @@ var Perm = /** @class */ (function () {
     Perm.bypassVoteFreeze = new Perm("bypassVoteFreeze", "trusted");
     Perm.bypassVotekick = new Perm("bypassVotekick", "mod");
     Perm.warn = new Perm("warn", "mod");
+    Perm.vanish = new Perm("vanish", "mod");
     Perm.changeTeam = new Perm("changeTeam", function (fishP) {
         return config_1.Mode.sandbox() ? fishP.ranksAtLeast("trusted")
             : config_1.Mode.attack() ? fishP.ranksAtLeast("admin")

--- a/scripts/commands.ts
+++ b/scripts/commands.ts
@@ -63,6 +63,7 @@ export class Perm {
 	static bypassVoteFreeze = new Perm("bypassVoteFreeze", "trusted");
 	static bypassVotekick = new Perm("bypassVotekick", "mod");
 	static warn = new Perm("warn", "mod");
+	static vanish = new Perm("vanish", "mod");
 	static changeTeam = new Perm("changeTeam", fishP => 
 		Mode.sandbox() ? fishP.ranksAtLeast("trusted")
 			: Mode.attack() ? fishP.ranksAtLeast("admin")

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -167,7 +167,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
     }, vanish: {
         args: ['target:player?'],
         description: "Toggles visibility of your rank and flags.",
-        perm: commands_1.Perm.trusted,
+        perm: commands_1.Perm.mod,
         handler: function (_a) {
             var _b;
             var args = _a.args, sender = _a.sender, outputSuccess = _a.outputSuccess;
@@ -178,7 +178,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
             (_b = args.target) !== null && _b !== void 0 ? _b : (args.target = sender);
             if (sender != args.target && args.target.hasPerm("blockTrolling"))
                 (0, commands_1.fail)("Target is insufficentlly trollable.");
-            if (sender != args.target && !sender.ranksAtLeast("admin"))
+            if (sender != args.target && !sender.ranksAtLeast("mod"))
                 (0, commands_1.fail)("Insufficent rank to vanish other players.");
             args.target.showPrefix = !args.target.showPrefix;
             outputSuccess((args.target == sender) ? ("Your") : ("".concat(args.target.name, "'s")) + " rank prefix is now ".concat(args.target.showPrefix ? "visible" : "hidden", "."));

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -763,7 +763,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
             Vars.maps.setNextMapOverride(args.map);
             if (allCommands.nextmap.data.voteEndTime() > -1) {
                 //Cancel /nextmap vote if it's ongoing
-                allCommands.nextmap.data.cancelVotes();
+                allCommands.nextmap.data.cancelVote();
                 Call.sendMessage("[red]Admin ".concat(sender.name, "[red] has cancelled the vote. The next map will be [yellow]").concat(args.map.name(), "."));
             }
         },
@@ -787,7 +787,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
             voteEndTime = -1;
         }
         /** Must be called only if there is an ongoing vote. */
-        function cancelVotes() {
+        function cancelVote() {
             resetVotes();
             task.cancel();
         }
@@ -802,7 +802,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
         }
         function startVote() {
             voteEndTime = Date.now() + voteDuration;
-            Timer.schedule(endVote, voteDuration / 1000);
+            task = Timer.schedule(endVote, voteDuration / 1000);
         }
         function endVote() {
             if (voteEndTime == -1)
@@ -833,7 +833,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
             args: ['map:map'],
             description: 'Allows you to vote for the next map. Use /maps to see all available maps.',
             perm: commands_1.Perm.play,
-            data: { votes: votes, voteEndTime: function () { return voteEndTime; }, resetVotes: resetVotes, endVote: endVote },
+            data: { votes: votes, voteEndTime: function () { return voteEndTime; }, resetVotes: resetVotes, endVote: endVote, cancelVote: cancelVote },
             handler: function (_a) {
                 var map = _a.args.map, sender = _a.sender, lastUsedSuccessfullySender = _a.lastUsedSuccessfullySender;
                 if (config_1.Mode.hexed())

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -166,12 +166,16 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
         },
     }, vanish: {
         args: [],
-        description: "Toggles visibility of your rank prefix.",
+        description: "Toggles visibility of your rank and flags.",
         perm: commands_1.Perm.trusted,
         handler: function (_a) {
             var sender = _a.sender, outputSuccess = _a.outputSuccess;
-            sender.showRankPrefix = !sender.showRankPrefix;
-            outputSuccess("Your rank prefix is now ".concat(sender.showRankPrefix ? "visible" : "hidden", "."));
+            if (sender.stelled())
+                (0, commands_1.fail)("Marked players may not hide flags.");
+            if (sender.muted)
+                (0, commands_1.fail)("Muted players may not hide flags.");
+            sender.showPrefix = !sender.showPrefix;
+            outputSuccess("Your rank prefix is now ".concat(sender.showPrefix ? "visible" : "hidden", "."));
         },
     }, tileid: {
         args: [],

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -180,8 +180,8 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
                 (0, commands_1.fail)("Target is insufficentlly trollable.");
             if (sender != args.target && !sender.ranksAtLeast("mod"))
                 (0, commands_1.fail)("Insufficent rank to vanish other players.");
-            args.target.showPrefix = !args.target.showPrefix;
-            outputSuccess((args.target == sender) ? ("Your") : ("".concat(args.target.name, "'s")) + " rank prefix is now ".concat(args.target.showPrefix ? "visible" : "hidden", "."));
+            args.target.showRankPrefix = !args.target.showRankPrefix;
+            outputSuccess((args.target == sender) ? ("Your") : ("".concat(args.target.name, "'s")) + " rank prefix is now ".concat(args.target.showRankPrefix ? "visible" : "hidden", "."));
         },
     }, tileid: {
         args: [],

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -178,10 +178,10 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
             (_b = args.target) !== null && _b !== void 0 ? _b : (args.target = sender);
             if (sender != args.target && args.target.hasPerm("blockTrolling"))
                 (0, commands_1.fail)("Target is insufficentlly trollable.");
-            if (sender != args.target && sender.ranksAtLeast("admin"))
+            if (sender != args.target && !sender.ranksAtLeast("admin"))
                 (0, commands_1.fail)("Insufficent rank to vanish other players.");
             args.target.showPrefix = !args.target.showPrefix;
-            outputSuccess("Your rank prefix is now ".concat(sender.showPrefix ? "visible" : "hidden", "."));
+            outputSuccess((args.target == sender) ? ("Your") : ("".concat(args.target.name, "'s")) + " rank prefix is now ".concat(args.target.showPrefix ? "visible" : "hidden", "."));
         },
     }, tileid: {
         args: [],
@@ -306,7 +306,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
         }
         function resume(target) {
             if (!Spectators.has(target))
-                return;
+                return; //ohno, they got trapped
             target.player.team(Spectators.get(target));
             Spectators.delete(target);
             target.forceRespawn();
@@ -755,15 +755,15 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
     //	 }
     // },
     //this was made with bees in mind
-    forceNextMap: {
+    overridemap: {
         args: ["map:map"],
-        description: 'Override the next map in queue',
+        description: 'Override the next map in queue.',
         perm: commands_1.Perm.admin,
         handler: function (_a) {
-            var args = _a.args, sender = _a.sender, outputSuccess = _a.outputSuccess;
+            var args = _a.args, sender = _a.sender;
             Vars.maps.setNextMapOverride(args.map);
-            commands_1.allCommands.nextmap.data.votes.clear();
-            outputSuccess("[red]Admin ".concat(sender.name, " has cancelled the vote. The next map will be [yellow]").concat(args.map.name(), "."));
+            commands_1.allCommands.nextmap.data.resetVotes();
+            Call.sendMessage("[red]Admin ".concat(sender.name, "[red] has cancelled the vote. The next map will be [yellow]").concat(args.map.name(), "."));
         },
     }, maps: {
         args: [],

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -167,7 +167,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
     }, vanish: {
         args: ['target:player?'],
         description: "Toggles visibility of your rank and flags.",
-        perm: commands_1.Perm.mod,
+        perm: commands_1.Perm.vanish,
         handler: function (_a) {
             var _b;
             var args = _a.args, sender = _a.sender, outputSuccess = _a.outputSuccess;

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -320,12 +320,14 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
         });
         return {
             args: ['target:player?'],
-            description: "Toggles spectator mode in pvp games",
+            description: "Toggles spectator mode in PVP games.",
             perm: commands_1.Perm.play,
             handler: function (_a) {
                 var _b;
                 var args = _a.args, sender = _a.sender, outputSuccess = _a.outputSuccess;
                 (_b = args.target) !== null && _b !== void 0 ? _b : (args.target = sender);
+                if (!(config_1.Mode.hexed() || config_1.Mode.pvp()) && !sender.ranksAtLeast("mod"))
+                    (0, commands_1.fail)("Insufficent rank to spectate on a non-pvp server.");
                 if (args.target !== sender && args.target.hasPerm("blockTrolling"))
                     (0, commands_1.fail)("Insufficent permission to force target to spectate.");
                 if (args.target !== sender && !sender.ranksAtLeast("admin"))
@@ -336,7 +338,7 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
                 }
                 else {
                     spectate(args.target);
-                    outputSuccess((args.target == sender) ? ("Joined team spectators. Run /spectate again to resume gameplay.") : ("Forced ".concat(args.target.name, " into spectator mode")));
+                    outputSuccess((args.target == sender) ? ("Joined team spectators. Run /spectate again to resume gameplay.") : ("Forced ".concat(args.target.name, " into spectator mode.")));
                 }
             }
         };
@@ -752,7 +754,18 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
     // 		votekickmanager.handleVote(sender, args ? 1 : -1);
     //	 }
     // },
-    maps: {
+    //this was made with bees in mind
+    forceNextMap: {
+        args: ["map:map"],
+        description: 'Override the next map in queue',
+        perm: commands_1.Perm.admin,
+        handler: function (_a) {
+            var args = _a.args, sender = _a.sender, outputSuccess = _a.outputSuccess;
+            Vars.maps.setNextMapOverride(args.map);
+            commands_1.allCommands.nextmap.data.votes.clear();
+            outputSuccess("[red]Admin ".concat(sender.name, " has cancelled the vote. The next map will be [yellow]").concat(args.map.name(), "."));
+        },
+    }, maps: {
         args: [],
         description: 'Lists the available maps.',
         perm: commands_1.Perm.none,

--- a/scripts/playerCommands.js
+++ b/scripts/playerCommands.js
@@ -165,16 +165,22 @@ exports.commands = (0, commands_1.commandList)(__assign(__assign({ unpause: {
                 outputSuccess("You are no longer marked as AFK.");
         },
     }, vanish: {
-        args: [],
+        args: ['target:player?'],
         description: "Toggles visibility of your rank and flags.",
         perm: commands_1.Perm.trusted,
         handler: function (_a) {
-            var sender = _a.sender, outputSuccess = _a.outputSuccess;
+            var _b;
+            var args = _a.args, sender = _a.sender, outputSuccess = _a.outputSuccess;
             if (sender.stelled())
                 (0, commands_1.fail)("Marked players may not hide flags.");
             if (sender.muted)
                 (0, commands_1.fail)("Muted players may not hide flags.");
-            sender.showPrefix = !sender.showPrefix;
+            (_b = args.target) !== null && _b !== void 0 ? _b : (args.target = sender);
+            if (sender != args.target && args.target.hasPerm("blockTrolling"))
+                (0, commands_1.fail)("Target is insufficentlly trollable.");
+            if (sender != args.target && sender.ranksAtLeast("admin"))
+                (0, commands_1.fail)("Insufficent rank to vanish other players.");
+            args.target.showPrefix = !args.target.showPrefix;
             outputSuccess("Your rank prefix is now ".concat(sender.showPrefix ? "visible" : "hidden", "."));
         },
     }, tileid: {

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -132,8 +132,8 @@ export const commands = commandList({
 			args.target ??= sender;
 			if(sender != args.target && args.target.hasPerm("blockTrolling")) fail(`Target is insufficentlly trollable.`);
 			if(sender != args.target && !sender.ranksAtLeast("mod")) fail(`Insufficent rank to vanish other players.`);
-			args.target.showPrefix = !args.target.showPrefix;
-			outputSuccess((args.target == sender)?(`Your`):(`${args.target.name}'s`) + ` rank prefix is now ${args.target.showPrefix ? "visible" : "hidden"}.`);
+			args.target.showRankPrefix = !args.target.showRankPrefix;
+			outputSuccess((args.target == sender)?(`Your`):(`${args.target.name}'s`) + ` rank prefix is now ${args.target.showRankPrefix ? "visible" : "hidden"}.`);
 		},
 	},
 	

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -125,13 +125,13 @@ export const commands = commandList({
 	vanish: {
 		args: ['target:player?'], 
 		description: `Toggles visibility of your rank and flags.`,
-		perm: Perm.trusted,
+		perm: Perm.mod,
 		handler({args,sender, outputSuccess}){
 			if(sender.stelled()) fail(`Marked players may not hide flags.`);
 			if(sender.muted) fail (`Muted players may not hide flags.`);
 			args.target ??= sender;
 			if(sender != args.target && args.target.hasPerm("blockTrolling")) fail(`Target is insufficentlly trollable.`);
-			if(sender != args.target && !sender.ranksAtLeast("admin")) fail(`Insufficent rank to vanish other players.`);
+			if(sender != args.target && !sender.ranksAtLeast("mod")) fail(`Insufficent rank to vanish other players.`);
 			args.target.showPrefix = !args.target.showPrefix;
 			outputSuccess((args.target == sender)?(`Your`):(`${args.target.name}'s`) + ` rank prefix is now ${args.target.showPrefix ? "visible" : "hidden"}.`);
 		},

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -124,11 +124,13 @@ export const commands = commandList({
 	},
 	vanish: {
 		args: [],
-		description: `Toggles visibility of your rank prefix.`,
+		description: `Toggles visibility of your rank and flags.`,
 		perm: Perm.trusted,
 		handler({sender, outputSuccess}){
-			sender.showRankPrefix = !sender.showRankPrefix;
-			outputSuccess(`Your rank prefix is now ${sender.showRankPrefix ? "visible" : "hidden"}.`);
+			if(sender.stelled()) fail(`Marked players may not hide flags.`);
+			if(sender.muted) fail (`Muted players may not hide flags.`);
+			sender.showPrefix = !sender.showPrefix;
+			outputSuccess(`Your rank prefix is now ${sender.showPrefix ? "visible" : "hidden"}.`);
 		},
 	},
 	

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -1,5 +1,5 @@
 import * as api from './api';
-import { command, commandList, fail, formatArg, Perm } from './commands';
+import { allCommands, command, commandList, fail, formatArg, Perm } from './commands';
 import { FishServers, Mode, rules } from './config';
 import { ipPortPattern, recentWhispers, tileHistory, uuidPattern } from './globals';
 import { menu } from './menus';
@@ -269,10 +269,11 @@ export const commands = commandList({
 		});
 		return {
 			args : ['target:player?'],
-			description : `Toggles spectator mode in pvp games`,
+			description : `Toggles spectator mode in PVP games.`,
 			perm: Perm.play,
 			handler({args,sender,outputSuccess}){
 				args.target ??= sender;
+				if(!(Mode.hexed() || Mode.pvp ()) && !sender.ranksAtLeast("mod")) fail (`Insufficent rank to spectate on a non-pvp server.`);
 				if(args.target !== sender && args.target.hasPerm("blockTrolling")) fail(`Insufficent permission to force target to spectate.`);
 				if(args.target !== sender && !sender.ranksAtLeast("admin")) fail(`Insufficent permission to force another player to spectate.`);
 				if(Spectators.has(args.target)){
@@ -280,7 +281,7 @@ export const commands = commandList({
 					outputSuccess((args.target == sender) ? (`Rejoining game as team ${args.target.team()}.`):(`Forced ${args.target.name} out of spectator mode.`));
 				}else{
 					spectate(args.target);
-					outputSuccess((args.target == sender) ? (`Joined team spectators. Run /spectate again to resume gameplay.`):(`Forced ${args.target.name} into spectator mode`));
+					outputSuccess((args.target == sender) ? (`Joined team spectators. Run /spectate again to resume gameplay.`):(`Forced ${args.target.name} into spectator mode.`));
 				}
 			}
 		};
@@ -728,6 +729,19 @@ Please stop attacking and [lime]build defenses[] first!`
 	// 		votekickmanager.handleVote(sender, args ? 1 : -1);
 	//	 }
 	// },
+
+	//this was made with bees in mind
+	forceNextMap:{
+		args: ["map:map"],
+		description: 'Override the next map in queue',
+		perm: Perm.admin,
+		handler({args,sender,outputSuccess}){
+			Vars.maps.setNextMapOverride(args.map);
+			allCommands.nextmap.data.votes.clear();
+			outputSuccess(`[red]Admin ${sender.name} has cancelled the vote. The next map will be [yellow]${args.map.name()}.`);
+		},
+
+	},
 
 	maps: {
 		args: [],

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -123,13 +123,16 @@ export const commands = commandList({
 		},
 	},
 	vanish: {
-		args: [],
+		args: ['target:player?'], 
 		description: `Toggles visibility of your rank and flags.`,
 		perm: Perm.trusted,
-		handler({sender, outputSuccess}){
+		handler({args,sender, outputSuccess}){
 			if(sender.stelled()) fail(`Marked players may not hide flags.`);
 			if(sender.muted) fail (`Muted players may not hide flags.`);
-			sender.showPrefix = !sender.showPrefix;
+			args.target ??= sender
+			if(sender != args.target && args.target.hasPerm("blockTrolling")) fail(`Target is insufficentlly trollable.`);
+			if(sender != args.target && sender.ranksAtLeast("admin")) fail(`Insufficent rank to vanish other players.`);
+			args.target.showPrefix = !args.target.showPrefix;
 			outputSuccess(`Your rank prefix is now ${sender.showPrefix ? "visible" : "hidden"}.`);
 		},
 	},

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -126,7 +126,7 @@ export const commands = commandList({
 		args: ['target:player?'], 
 		description: `Toggles visibility of your rank and flags.`,
 		perm: Perm.vanish,
-		handler({args,sender, outputSuccess}){
+		handler({ args, sender, outputSuccess }){
 			if(sender.stelled()) fail(`Marked players may not hide flags.`);
 			if(sender.muted) fail (`Muted players may not hide flags.`);
 			args.target ??= sender;
@@ -738,7 +738,7 @@ Please stop attacking and [lime]build defenses[] first!`
 			Vars.maps.setNextMapOverride(args.map);
 			if(allCommands.nextmap.data.voteEndTime() > -1){
 				//Cancel /nextmap vote if it's ongoing
-				allCommands.nextmap.data.cancelVotes();
+				allCommands.nextmap.data.cancelVote();
 				Call.sendMessage(`[red]Admin ${sender.name}[red] has cancelled the vote. The next map will be [yellow]${args.map.name()}.`);
 			}
 		},
@@ -774,7 +774,7 @@ ${Vars.maps.customMaps().toArray().map((map, i) =>
 		}
 
 		/** Must be called only if there is an ongoing vote. */
-		function cancelVotes(){
+		function cancelVote(){
 			resetVotes();
 			task!.cancel();
 		}
@@ -797,7 +797,7 @@ ${getMapData().map(({key:map, value:votes}) =>
 
 		function startVote(){
 			voteEndTime = Date.now() + voteDuration;
-			Timer.schedule(endVote, voteDuration / 1000);
+			task = Timer.schedule(endVote, voteDuration / 1000);
 		}
 
 		function endVote(){
@@ -833,7 +833,7 @@ ${getMapData().map(({key:map, value:votes}) =>
 			args: ['map:map'],
 			description: 'Allows you to vote for the next map. Use /maps to see all available maps.',
 			perm: Perm.play,
-			data: {votes, voteEndTime: () => voteEndTime, resetVotes, endVote},
+			data: {votes, voteEndTime: () => voteEndTime, resetVotes, endVote, cancelVote},
 			handler({args:{map}, sender, lastUsedSuccessfullySender}){
 				if(Mode.hexed()) fail(`This command is disabled in Hexed.`);
 				if(votes.get(sender)) fail(`You have already voted.`);

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -125,7 +125,7 @@ export const commands = commandList({
 	vanish: {
 		args: ['target:player?'], 
 		description: `Toggles visibility of your rank and flags.`,
-		perm: Perm.mod,
+		perm: Perm.vanish,
 		handler({args,sender, outputSuccess}){
 			if(sender.stelled()) fail(`Marked players may not hide flags.`);
 			if(sender.muted) fail (`Muted players may not hide flags.`);

--- a/scripts/playerCommands.ts
+++ b/scripts/playerCommands.ts
@@ -129,11 +129,11 @@ export const commands = commandList({
 		handler({args,sender, outputSuccess}){
 			if(sender.stelled()) fail(`Marked players may not hide flags.`);
 			if(sender.muted) fail (`Muted players may not hide flags.`);
-			args.target ??= sender
+			args.target ??= sender;
 			if(sender != args.target && args.target.hasPerm("blockTrolling")) fail(`Target is insufficentlly trollable.`);
-			if(sender != args.target && sender.ranksAtLeast("admin")) fail(`Insufficent rank to vanish other players.`);
+			if(sender != args.target && !sender.ranksAtLeast("admin")) fail(`Insufficent rank to vanish other players.`);
 			args.target.showPrefix = !args.target.showPrefix;
-			outputSuccess(`Your rank prefix is now ${sender.showPrefix ? "visible" : "hidden"}.`);
+			outputSuccess((args.target == sender)?(`Your`):(`${args.target.name}'s`) + ` rank prefix is now ${args.target.showPrefix ? "visible" : "hidden"}.`);
 		},
 	},
 	
@@ -256,7 +256,7 @@ export const commands = commandList({
 			target.forceRespawn();
 		}
 		function resume(target:FishPlayer):void{
-			if(!Spectators.has(target)) return; 
+			if(!Spectators.has(target)) return; //ohno, they got trapped
 			target.player.team(Spectators.get(target));
 			Spectators.delete(target);
 			target.forceRespawn()
@@ -731,14 +731,14 @@ Please stop attacking and [lime]build defenses[] first!`
 	// },
 
 	//this was made with bees in mind
-	forceNextMap:{
+	overridemap:{
 		args: ["map:map"],
-		description: 'Override the next map in queue',
+		description: 'Override the next map in queue.',
 		perm: Perm.admin,
-		handler({args,sender,outputSuccess}){
+		handler({args,sender}){
 			Vars.maps.setNextMapOverride(args.map);
-			allCommands.nextmap.data.votes.clear();
-			outputSuccess(`[red]Admin ${sender.name} has cancelled the vote. The next map will be [yellow]${args.map.name()}.`);
+			allCommands.nextmap.data.resetVotes()
+			Call.sendMessage(`[red]Admin ${sender.name}[red] has cancelled the vote. The next map will be [yellow]${args.map.name()}.`);
 		},
 
 	},

--- a/scripts/players.js
+++ b/scripts/players.js
@@ -61,7 +61,7 @@ var FishPlayer = /** @class */ (function () {
         this.tileId = false;
         this.tilelog = null;
         this.trail = null;
-        this.showPrefix = true;
+        this.showRankPrefix = true;
         /** Used to freeze players when votekicking. */
         this.frozen = false;
         this.usageData = {};
@@ -328,7 +328,6 @@ var FishPlayer = /** @class */ (function () {
             fishPlayer.updateAdminStatus();
             fishPlayer.updateMemberExclusiveState();
             fishPlayer.checkVPNAndJoins();
-            fishPlayer.unvanish();
             // fishPlayer.checkAutoRanks();
             api.getStopped(player.uuid(), function (unmarkTime) {
                 if (unmarkTime)
@@ -528,7 +527,7 @@ var FishPlayer = /** @class */ (function () {
             prefix += config.MUTED_PREFIX;
         if (this.afk())
             prefix += "[orange]\uE876 AFK \uE876 | [white]";
-        if (this.showPrefix) {
+        if (this.showRankPrefix) {
             try {
                 for (var _b = __values(this.flags), _c = _b.next(); !_c.done; _c = _b.next()) {
                     var flag = _c.value;
@@ -542,9 +541,8 @@ var FishPlayer = /** @class */ (function () {
                 }
                 finally { if (e_6) throw e_6.error; }
             }
-        }
-        if (this.showPrefix)
             prefix += this.rank.prefix;
+        }
         if (prefix.length > 0)
             prefix += " ";
         var replacedName;
@@ -683,12 +681,6 @@ var FishPlayer = /** @class */ (function () {
     FishPlayer.prototype.displayTrail = function () {
         if (this.trail)
             Call.effect(Fx[this.trail.type], this.player.x, this.player.y, 0, this.trail.color);
-    };
-    //temperary code to de-vanish all the trusted players
-    FishPlayer.prototype.unvanish = function () {
-        if (!this.showPrefix && !this.ranksAtLeast(ranks_1.Rank.mod)) {
-            this.showPrefix = true;
-        }
     };
     FishPlayer.prototype.sendWelcomeMessage = function () {
         var _this = this;
@@ -1228,7 +1220,7 @@ var FishPlayer = /** @class */ (function () {
             time: Date.now(),
         });
         this.setPunishedIP(config.stopAntiEvadeTime);
-        this.showPrefix = true;
+        this.showRankPrefix = true;
         this.updateName();
         if (this.connected() && notify) {
             this.stopUnit();
@@ -1308,7 +1300,7 @@ var FishPlayer = /** @class */ (function () {
         if (this.muted)
             return;
         this.muted = true;
-        this.showPrefix = true;
+        this.showRankPrefix = true;
         this.updateName();
         this.sendMessage("[yellow] Hey! You have been muted. You can still use /msg to send a message to someone.");
         this.setPunishedIP(config.stopAntiEvadeTime);

--- a/scripts/players.js
+++ b/scripts/players.js
@@ -49,10 +49,10 @@ var ranks_1 = require("./ranks");
 var utils_1 = require("./utils");
 var FishPlayer = /** @class */ (function () {
     function FishPlayer(_a, player) {
-        var uuid = _a.uuid, name = _a.name, _b = _a.muted, muted = _b === void 0 ? false : _b, _c = _a.autoflagged, autoflagged = _c === void 0 ? false : _c, _d = _a.unmarkTime, unmarked = _d === void 0 ? -1 : _d, _e = _a.highlight, highlight = _e === void 0 ? null : _e, _f = _a.history, history = _f === void 0 ? [] : _f, _g = _a.rainbow, rainbow = _g === void 0 ? null : _g, _h = _a.rank, rank = _h === void 0 ? "player" : _h, _j = _a.flags, flags = _j === void 0 ? [] : _j, usid = _a.usid, _k = _a.chatStrictness, chatStrictness = _k === void 0 ? "chat" : _k, lastJoined = _a.lastJoined, stats = _a.stats, 
+        var uuid = _a.uuid, name = _a.name, _b = _a.muted, muted = _b === void 0 ? false : _b, _c = _a.autoflagged, autoflagged = _c === void 0 ? false : _c, _d = _a.unmarkTime, unmarked = _d === void 0 ? -1 : _d, _e = _a.highlight, highlight = _e === void 0 ? null : _e, _f = _a.history, history = _f === void 0 ? [] : _f, _g = _a.rainbow, rainbow = _g === void 0 ? null : _g, _h = _a.rank, rank = _h === void 0 ? "player" : _h, _j = _a.flags, flags = _j === void 0 ? [] : _j, usid = _a.usid, _k = _a.chatStrictness, chatStrictness = _k === void 0 ? "chat" : _k, lastJoined = _a.lastJoined, stats = _a.stats, _l = _a.showRankPrefix, showRankPrefix = _l === void 0 ? true : _l, 
         //deprecated
         member = _a.member, stopped = _a.stopped;
-        var _l, _m, _o, _p;
+        var _m, _o, _p, _q;
         //Transients
         this.player = null;
         this.pet = "";
@@ -61,7 +61,6 @@ var FishPlayer = /** @class */ (function () {
         this.tileId = false;
         this.tilelog = null;
         this.trail = null;
-        this.showRankPrefix = true;
         /** Used to freeze players when votekicking. */
         this.frozen = false;
         this.usageData = {};
@@ -83,8 +82,8 @@ var FishPlayer = /** @class */ (function () {
         this.lastActive = Date.now();
         this.lastRatelimitedMessage = -1;
         this.chatStrictness = "chat";
-        this.uuid = (_l = uuid !== null && uuid !== void 0 ? uuid : player === null || player === void 0 ? void 0 : player.uuid()) !== null && _l !== void 0 ? _l : (0, utils_1.crash)("Attempted to create FishPlayer with no UUID");
-        this.name = (_m = name !== null && name !== void 0 ? name : player === null || player === void 0 ? void 0 : player.name) !== null && _m !== void 0 ? _m : "Unnamed player [ERROR]";
+        this.uuid = (_m = uuid !== null && uuid !== void 0 ? uuid : player === null || player === void 0 ? void 0 : player.uuid()) !== null && _m !== void 0 ? _m : (0, utils_1.crash)("Attempted to create FishPlayer with no UUID");
+        this.name = (_o = name !== null && name !== void 0 ? name : player === null || player === void 0 ? void 0 : player.name) !== null && _o !== void 0 ? _o : "Unnamed player [ERROR]";
         this.muted = muted;
         this.unmarkTime = unmarked;
         if (stopped)
@@ -96,7 +95,7 @@ var FishPlayer = /** @class */ (function () {
         this.player = player;
         this.rainbow = rainbow;
         this.cleanedName = (0, utils_1.escapeStringColorsServer)(Strings.stripColors(this.name));
-        this.rank = (_o = ranks_1.Rank.getByName(rank)) !== null && _o !== void 0 ? _o : ranks_1.Rank.player;
+        this.rank = (_p = ranks_1.Rank.getByName(rank)) !== null && _p !== void 0 ? _p : ranks_1.Rank.player;
         this.flags = new Set(flags.map(ranks_1.RoleFlag.getByName).filter(function (f) { return f != null; }));
         if (member)
             this.flags.add(ranks_1.RoleFlag.member);
@@ -104,7 +103,7 @@ var FishPlayer = /** @class */ (function () {
             this.rank = ranks_1.Rank.admin;
             this.flags.add(ranks_1.RoleFlag.developer);
         }
-        this.usid = (_p = usid !== null && usid !== void 0 ? usid : player === null || player === void 0 ? void 0 : player.usid()) !== null && _p !== void 0 ? _p : null;
+        this.usid = (_q = usid !== null && usid !== void 0 ? usid : player === null || player === void 0 ? void 0 : player.usid()) !== null && _q !== void 0 ? _q : null;
         this.chatStrictness = chatStrictness;
         this.stats = stats !== null && stats !== void 0 ? stats : {
             blocksBroken: 0,
@@ -114,6 +113,7 @@ var FishPlayer = /** @class */ (function () {
             gamesFinished: 0,
             gamesWon: 0,
         };
+        this.showRankPrefix = showRankPrefix;
     }
     //#region getplayer
     //Contains methods used to get FishPlayer instances.
@@ -690,6 +690,8 @@ var FishPlayer = /** @class */ (function () {
             this.sendMessage("[gold]Hello there! You are currently [red]muted[]. You can still play normally, but cannot send chat messages to other non-staff players while muted.\nTo appeal, [#7289da]join our discord[] with [#7289da]/discord[], or ask a ".concat(ranks_1.Rank.mod.color, "staff member[] in-game.\nWe apologize for the inconvenience."));
         else if (this.autoflagged)
             this.sendMessage("[gold]Hello there! You are currently [red]flagged as suspicious[]. You cannot do anything in-game.\nTo appeal, [#7289da]join our discord[] with [#7289da]/discord[], or ask a ".concat(ranks_1.Rank.mod.color, "staff member[] in-game.\nWe apologize for the inconvenience."));
+        else if (!this.showRankPrefix)
+            this.sendMessage("[gold]Hello there! Your rank prefix is currently hidden. You can show it again by running [white]/vanish[].");
         else {
             this.sendMessage("[gold]Welcome![]");
             //show tips
@@ -745,7 +747,7 @@ var FishPlayer = /** @class */ (function () {
         return new this(JSON.parse(fishPlayerData), player);
     };
     FishPlayer.read = function (version, fishPlayerData, player) {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z;
         switch (version) {
             case 0:
                 return new this({
@@ -911,6 +913,38 @@ var FishPlayer = /** @class */ (function () {
                         gamesWon: fishPlayerData.readNumber(5),
                     }
                 }, player);
+            case 8:
+                return new this({
+                    uuid: (_x = fishPlayerData.readString(2)) !== null && _x !== void 0 ? _x : (0, utils_1.crash)("Failed to deserialize FishPlayer: UUID was null."),
+                    name: (_y = fishPlayerData.readString(2)) !== null && _y !== void 0 ? _y : "Unnamed player [ERROR]",
+                    muted: fishPlayerData.readBool(),
+                    autoflagged: fishPlayerData.readBool(),
+                    unmarkTime: fishPlayerData.readNumber(13),
+                    highlight: fishPlayerData.readString(2),
+                    history: fishPlayerData.readArray(function (str) {
+                        var _a, _b;
+                        return ({
+                            action: (_a = str.readString(2)) !== null && _a !== void 0 ? _a : "null",
+                            by: (_b = str.readString(2)) !== null && _b !== void 0 ? _b : "null",
+                            time: str.readNumber(15)
+                        });
+                    }),
+                    rainbow: (function (n) { return n == 0 ? null : { speed: n }; })(fishPlayerData.readNumber(2)),
+                    rank: (_z = fishPlayerData.readString(2)) !== null && _z !== void 0 ? _z : "",
+                    flags: fishPlayerData.readArray(function (str) { return str.readString(2); }, 2).filter(function (s) { return s != null; }),
+                    usid: fishPlayerData.readString(2),
+                    chatStrictness: fishPlayerData.readEnumString(["chat", "strict"]),
+                    lastJoined: fishPlayerData.readNumber(15),
+                    stats: {
+                        blocksBroken: fishPlayerData.readNumber(10),
+                        blocksPlaced: fishPlayerData.readNumber(10),
+                        timeInGame: fishPlayerData.readNumber(15),
+                        chatMessagesSent: fishPlayerData.readNumber(7),
+                        gamesFinished: fishPlayerData.readNumber(5),
+                        gamesWon: fishPlayerData.readNumber(5),
+                    },
+                    showRankPrefix: fishPlayerData.readBool(),
+                }, player);
             default: (0, utils_1.crash)("Unknown save version ".concat(version));
         }
     };
@@ -941,6 +975,7 @@ var FishPlayer = /** @class */ (function () {
         out.writeNumber(this.stats.chatMessagesSent, 7, true);
         out.writeNumber(this.stats.gamesFinished, 5, true);
         out.writeNumber(this.stats.gamesWon, 5, true);
+        out.writeBool(this.showRankPrefix);
     };
     /**Saves cached FishPlayers to JSON in Core.settings. */
     FishPlayer.saveAll = function () {
@@ -1408,7 +1443,7 @@ var FishPlayer = /** @class */ (function () {
     };
     FishPlayer.cachedPlayers = {};
     FishPlayer.maxHistoryLength = 5;
-    FishPlayer.saveVersion = 7;
+    FishPlayer.saveVersion = 8;
     FishPlayer.chunkSize = 50000;
     //Static transients
     FishPlayer.stats = {

--- a/scripts/players.js
+++ b/scripts/players.js
@@ -61,7 +61,7 @@ var FishPlayer = /** @class */ (function () {
         this.tileId = false;
         this.tilelog = null;
         this.trail = null;
-        this.showRankPrefix = true;
+        this.showPrefix = true;
         /** Used to freeze players when votekicking. */
         this.frozen = false;
         this.usageData = {};
@@ -527,20 +527,22 @@ var FishPlayer = /** @class */ (function () {
             prefix += config.MUTED_PREFIX;
         if (this.afk())
             prefix += "[orange]\uE876 AFK \uE876 | [white]";
-        try {
-            for (var _b = __values(this.flags), _c = _b.next(); !_c.done; _c = _b.next()) {
-                var flag = _c.value;
-                prefix += flag.prefix;
-            }
-        }
-        catch (e_6_1) { e_6 = { error: e_6_1 }; }
-        finally {
+        if (this.showPrefix) {
             try {
-                if (_c && !_c.done && (_a = _b.return)) _a.call(_b);
+                for (var _b = __values(this.flags), _c = _b.next(); !_c.done; _c = _b.next()) {
+                    var flag = _c.value;
+                    prefix += flag.prefix;
+                }
             }
-            finally { if (e_6) throw e_6.error; }
+            catch (e_6_1) { e_6 = { error: e_6_1 }; }
+            finally {
+                try {
+                    if (_c && !_c.done && (_a = _b.return)) _a.call(_b);
+                }
+                finally { if (e_6) throw e_6.error; }
+            }
         }
-        if (this.showRankPrefix)
+        if (this.showPrefix)
             prefix += this.rank.prefix;
         if (prefix.length > 0)
             prefix += " ";
@@ -1219,6 +1221,7 @@ var FishPlayer = /** @class */ (function () {
             time: Date.now(),
         });
         this.setPunishedIP(config.stopAntiEvadeTime);
+        this.showPrefix = true;
         this.updateName();
         if (this.connected() && notify) {
             this.stopUnit();
@@ -1298,6 +1301,7 @@ var FishPlayer = /** @class */ (function () {
         if (this.muted)
             return;
         this.muted = true;
+        this.showPrefix = true;
         this.updateName();
         this.sendMessage("[yellow] Hey! You have been muted. You can still use /msg to send a message to someone.");
         this.setPunishedIP(config.stopAntiEvadeTime);

--- a/scripts/players.js
+++ b/scripts/players.js
@@ -328,6 +328,7 @@ var FishPlayer = /** @class */ (function () {
             fishPlayer.updateAdminStatus();
             fishPlayer.updateMemberExclusiveState();
             fishPlayer.checkVPNAndJoins();
+            fishPlayer.unvanish();
             // fishPlayer.checkAutoRanks();
             api.getStopped(player.uuid(), function (unmarkTime) {
                 if (unmarkTime)
@@ -682,6 +683,12 @@ var FishPlayer = /** @class */ (function () {
     FishPlayer.prototype.displayTrail = function () {
         if (this.trail)
             Call.effect(Fx[this.trail.type], this.player.x, this.player.y, 0, this.trail.color);
+    };
+    //temperary code to de-vanish all the trusted players
+    FishPlayer.prototype.unvanish = function () {
+        if (!this.showPrefix && !this.ranksAtLeast(ranks_1.Rank.mod)) {
+            this.showPrefix = true;
+        }
     };
     FishPlayer.prototype.sendWelcomeMessage = function () {
         var _this = this;

--- a/scripts/players.js
+++ b/scripts/players.js
@@ -49,9 +49,7 @@ var ranks_1 = require("./ranks");
 var utils_1 = require("./utils");
 var FishPlayer = /** @class */ (function () {
     function FishPlayer(_a, player) {
-        var uuid = _a.uuid, name = _a.name, _b = _a.muted, muted = _b === void 0 ? false : _b, _c = _a.autoflagged, autoflagged = _c === void 0 ? false : _c, _d = _a.unmarkTime, unmarked = _d === void 0 ? -1 : _d, _e = _a.highlight, highlight = _e === void 0 ? null : _e, _f = _a.history, history = _f === void 0 ? [] : _f, _g = _a.rainbow, rainbow = _g === void 0 ? null : _g, _h = _a.rank, rank = _h === void 0 ? "player" : _h, _j = _a.flags, flags = _j === void 0 ? [] : _j, usid = _a.usid, _k = _a.chatStrictness, chatStrictness = _k === void 0 ? "chat" : _k, lastJoined = _a.lastJoined, stats = _a.stats, _l = _a.showRankPrefix, showRankPrefix = _l === void 0 ? true : _l, 
-        //deprecated
-        member = _a.member, stopped = _a.stopped;
+        var uuid = _a.uuid, name = _a.name, _b = _a.muted, muted = _b === void 0 ? false : _b, _c = _a.autoflagged, autoflagged = _c === void 0 ? false : _c, _d = _a.unmarkTime, unmarked = _d === void 0 ? -1 : _d, _e = _a.highlight, highlight = _e === void 0 ? null : _e, _f = _a.history, history = _f === void 0 ? [] : _f, _g = _a.rainbow, rainbow = _g === void 0 ? null : _g, _h = _a.rank, rank = _h === void 0 ? "player" : _h, _j = _a.flags, flags = _j === void 0 ? [] : _j, usid = _a.usid, _k = _a.chatStrictness, chatStrictness = _k === void 0 ? "chat" : _k, lastJoined = _a.lastJoined, stats = _a.stats, _l = _a.showRankPrefix, showRankPrefix = _l === void 0 ? true : _l;
         var _m, _o, _p, _q;
         //Transients
         this.player = null;
@@ -86,8 +84,6 @@ var FishPlayer = /** @class */ (function () {
         this.name = (_o = name !== null && name !== void 0 ? name : player === null || player === void 0 ? void 0 : player.name) !== null && _o !== void 0 ? _o : "Unnamed player [ERROR]";
         this.muted = muted;
         this.unmarkTime = unmarked;
-        if (stopped)
-            this.unmarkTime = Date.now() + 2592000; //30 days
         this.lastJoined = lastJoined !== null && lastJoined !== void 0 ? lastJoined : -1;
         this.autoflagged = autoflagged;
         this.highlight = highlight;
@@ -97,12 +93,6 @@ var FishPlayer = /** @class */ (function () {
         this.cleanedName = (0, utils_1.escapeStringColorsServer)(Strings.stripColors(this.name));
         this.rank = (_p = ranks_1.Rank.getByName(rank)) !== null && _p !== void 0 ? _p : ranks_1.Rank.player;
         this.flags = new Set(flags.map(ranks_1.RoleFlag.getByName).filter(function (f) { return f != null; }));
-        if (member)
-            this.flags.add(ranks_1.RoleFlag.member);
-        if (rank == "developer") {
-            this.rank = ranks_1.Rank.admin;
-            this.flags.add(ranks_1.RoleFlag.developer);
-        }
         this.usid = (_q = usid !== null && usid !== void 0 ? usid : player === null || player === void 0 ? void 0 : player.usid()) !== null && _q !== void 0 ? _q : null;
         this.chatStrictness = chatStrictness;
         this.stats = stats !== null && stats !== void 0 ? stats : {
@@ -747,16 +737,24 @@ var FishPlayer = /** @class */ (function () {
         return new this(JSON.parse(fishPlayerData), player);
     };
     FishPlayer.read = function (version, fishPlayerData, player) {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z;
+        var _a, _b, _c, _d, _e, _f;
         switch (version) {
             case 0:
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+                (0, utils_1.crash)("Version ".concat(version, " is not longer supported, this should not be possible"));
+            case 6:
+            case 7:
                 return new this({
                     uuid: (_a = fishPlayerData.readString(2)) !== null && _a !== void 0 ? _a : (0, utils_1.crash)("Failed to deserialize FishPlayer: UUID was null."),
                     name: (_b = fishPlayerData.readString(2)) !== null && _b !== void 0 ? _b : "Unnamed player [ERROR]",
                     muted: fishPlayerData.readBool(),
-                    member: fishPlayerData.readBool(),
-                    stopped: fishPlayerData.readBool(),
-                    highlight: fishPlayerData.readString(3),
+                    autoflagged: fishPlayerData.readBool(),
+                    unmarkTime: fishPlayerData.readNumber(13),
+                    highlight: fishPlayerData.readString(2),
                     history: fishPlayerData.readArray(function (str) {
                         var _a, _b;
                         return ({
@@ -767,139 +765,6 @@ var FishPlayer = /** @class */ (function () {
                     }),
                     rainbow: (function (n) { return n == 0 ? null : { speed: n }; })(fishPlayerData.readNumber(2)),
                     rank: (_c = fishPlayerData.readString(2)) !== null && _c !== void 0 ? _c : "",
-                    usid: fishPlayerData.readString(3)
-                }, player);
-            case 1:
-                return new this({
-                    uuid: (_d = fishPlayerData.readString(2)) !== null && _d !== void 0 ? _d : (0, utils_1.crash)("Failed to deserialize FishPlayer: UUID was null."),
-                    name: (_e = fishPlayerData.readString(2)) !== null && _e !== void 0 ? _e : "Unnamed player [ERROR]",
-                    muted: fishPlayerData.readBool(),
-                    member: fishPlayerData.readBool(),
-                    stopped: fishPlayerData.readBool(),
-                    highlight: fishPlayerData.readString(2),
-                    history: fishPlayerData.readArray(function (str) {
-                        var _a, _b;
-                        return ({
-                            action: (_a = str.readString(2)) !== null && _a !== void 0 ? _a : "null",
-                            by: (_b = str.readString(2)) !== null && _b !== void 0 ? _b : "null",
-                            time: str.readNumber(15)
-                        });
-                    }),
-                    rainbow: (function (n) { return n == 0 ? null : { speed: n }; })(fishPlayerData.readNumber(2)),
-                    rank: (_f = fishPlayerData.readString(2)) !== null && _f !== void 0 ? _f : "",
-                    usid: fishPlayerData.readString(2)
-                }, player);
-            case 2:
-                return new this({
-                    uuid: (_g = fishPlayerData.readString(2)) !== null && _g !== void 0 ? _g : (0, utils_1.crash)("Failed to deserialize FishPlayer: UUID was null."),
-                    name: (_h = fishPlayerData.readString(2)) !== null && _h !== void 0 ? _h : "Unnamed player [ERROR]",
-                    muted: fishPlayerData.readBool(),
-                    stopped: fishPlayerData.readBool(),
-                    highlight: fishPlayerData.readString(2),
-                    history: fishPlayerData.readArray(function (str) {
-                        var _a, _b;
-                        return ({
-                            action: (_a = str.readString(2)) !== null && _a !== void 0 ? _a : "null",
-                            by: (_b = str.readString(2)) !== null && _b !== void 0 ? _b : "null",
-                            time: str.readNumber(15)
-                        });
-                    }),
-                    rainbow: (function (n) { return n == 0 ? null : { speed: n }; })(fishPlayerData.readNumber(2)),
-                    rank: (_j = fishPlayerData.readString(2)) !== null && _j !== void 0 ? _j : "",
-                    flags: fishPlayerData.readArray(function (str) { return str.readString(2); }, 2).filter(function (s) { return s != null; }),
-                    usid: fishPlayerData.readString(2)
-                }, player);
-            case 3:
-                //Extremely cursed due to a catastrophic error
-                var dataPart1 = {
-                    uuid: (_k = fishPlayerData.readString(2)) !== null && _k !== void 0 ? _k : (0, utils_1.crash)("Failed to deserialize FishPlayer: UUID was null."),
-                    name: (_l = fishPlayerData.readString(2)) !== null && _l !== void 0 ? _l : "Unnamed player [ERROR]",
-                    muted: fishPlayerData.readBool(),
-                    autoflagged: fishPlayerData.readBool()
-                };
-                var unmarkTime = void 0;
-                try {
-                    unmarkTime = fishPlayerData.readNumber(13);
-                }
-                catch (err) {
-                    Log.warn("Invalid stored unmark time: (".concat(err.message.split(": ")[1], ") Attempting repair..."));
-                    fishPlayerData.offset -= 13;
-                    var chars = fishPlayerData.read(24);
-                    if (chars !== dataPart1.uuid)
-                        (0, utils_1.crash)("Unable to repair data: next 24 chars ".concat(chars, " were not equal to uuid ").concat(dataPart1.uuid));
-                    Log.warn("Repaired stored data for ".concat(chars, "."));
-                    unmarkTime = -1; //the data is lost, set as default
-                }
-                return new this(__assign(__assign({}, dataPart1), { unmarkTime: unmarkTime, highlight: fishPlayerData.readString(2), history: fishPlayerData.readArray(function (str) {
-                        var _a, _b;
-                        return ({
-                            action: (_a = str.readString(2)) !== null && _a !== void 0 ? _a : "null",
-                            by: (_b = str.readString(2)) !== null && _b !== void 0 ? _b : "null",
-                            time: str.readNumber(15)
-                        });
-                    }), rainbow: (function (n) { return n == 0 ? null : { speed: n }; })(fishPlayerData.readNumber(2)), rank: (_m = fishPlayerData.readString(2)) !== null && _m !== void 0 ? _m : "", flags: fishPlayerData.readArray(function (str) { return str.readString(2); }, 2).filter(function (s) { return s != null; }), usid: fishPlayerData.readString(2) }), player);
-            case 4:
-                return new this({
-                    uuid: (_o = fishPlayerData.readString(2)) !== null && _o !== void 0 ? _o : (0, utils_1.crash)("Failed to deserialize FishPlayer: UUID was null."),
-                    name: (_p = fishPlayerData.readString(2)) !== null && _p !== void 0 ? _p : "Unnamed player [ERROR]",
-                    muted: fishPlayerData.readBool(),
-                    autoflagged: fishPlayerData.readBool(),
-                    unmarkTime: fishPlayerData.readNumber(13),
-                    highlight: fishPlayerData.readString(2),
-                    history: fishPlayerData.readArray(function (str) {
-                        var _a, _b;
-                        return ({
-                            action: (_a = str.readString(2)) !== null && _a !== void 0 ? _a : "null",
-                            by: (_b = str.readString(2)) !== null && _b !== void 0 ? _b : "null",
-                            time: str.readNumber(15)
-                        });
-                    }),
-                    rainbow: (function (n) { return n == 0 ? null : { speed: n }; })(fishPlayerData.readNumber(2)),
-                    rank: (_q = fishPlayerData.readString(2)) !== null && _q !== void 0 ? _q : "",
-                    flags: fishPlayerData.readArray(function (str) { return str.readString(2); }, 2).filter(function (s) { return s != null; }),
-                    usid: fishPlayerData.readString(2)
-                }, player);
-            case 5:
-                return new this({
-                    uuid: (_r = fishPlayerData.readString(2)) !== null && _r !== void 0 ? _r : (0, utils_1.crash)("Failed to deserialize FishPlayer: UUID was null."),
-                    name: (_s = fishPlayerData.readString(2)) !== null && _s !== void 0 ? _s : "Unnamed player [ERROR]",
-                    muted: fishPlayerData.readBool(),
-                    autoflagged: fishPlayerData.readBool(),
-                    unmarkTime: fishPlayerData.readNumber(13),
-                    highlight: fishPlayerData.readString(2),
-                    history: fishPlayerData.readArray(function (str) {
-                        var _a, _b;
-                        return ({
-                            action: (_a = str.readString(2)) !== null && _a !== void 0 ? _a : "null",
-                            by: (_b = str.readString(2)) !== null && _b !== void 0 ? _b : "null",
-                            time: str.readNumber(15)
-                        });
-                    }),
-                    rainbow: (function (n) { return n == 0 ? null : { speed: n }; })(fishPlayerData.readNumber(2)),
-                    rank: (_t = fishPlayerData.readString(2)) !== null && _t !== void 0 ? _t : "",
-                    flags: fishPlayerData.readArray(function (str) { return str.readString(2); }, 2).filter(function (s) { return s != null; }),
-                    usid: fishPlayerData.readString(2),
-                    chatStrictness: fishPlayerData.readEnumString(["chat", "strict"]),
-                }, player);
-            case 6:
-            case 7:
-                return new this({
-                    uuid: (_u = fishPlayerData.readString(2)) !== null && _u !== void 0 ? _u : (0, utils_1.crash)("Failed to deserialize FishPlayer: UUID was null."),
-                    name: (_v = fishPlayerData.readString(2)) !== null && _v !== void 0 ? _v : "Unnamed player [ERROR]",
-                    muted: fishPlayerData.readBool(),
-                    autoflagged: fishPlayerData.readBool(),
-                    unmarkTime: fishPlayerData.readNumber(13),
-                    highlight: fishPlayerData.readString(2),
-                    history: fishPlayerData.readArray(function (str) {
-                        var _a, _b;
-                        return ({
-                            action: (_a = str.readString(2)) !== null && _a !== void 0 ? _a : "null",
-                            by: (_b = str.readString(2)) !== null && _b !== void 0 ? _b : "null",
-                            time: str.readNumber(15)
-                        });
-                    }),
-                    rainbow: (function (n) { return n == 0 ? null : { speed: n }; })(fishPlayerData.readNumber(2)),
-                    rank: (_w = fishPlayerData.readString(2)) !== null && _w !== void 0 ? _w : "",
                     flags: fishPlayerData.readArray(function (str) { return str.readString(2); }, 2).filter(function (s) { return s != null; }),
                     usid: fishPlayerData.readString(2),
                     chatStrictness: fishPlayerData.readEnumString(["chat", "strict"]),
@@ -915,8 +780,8 @@ var FishPlayer = /** @class */ (function () {
                 }, player);
             case 8:
                 return new this({
-                    uuid: (_x = fishPlayerData.readString(2)) !== null && _x !== void 0 ? _x : (0, utils_1.crash)("Failed to deserialize FishPlayer: UUID was null."),
-                    name: (_y = fishPlayerData.readString(2)) !== null && _y !== void 0 ? _y : "Unnamed player [ERROR]",
+                    uuid: (_d = fishPlayerData.readString(2)) !== null && _d !== void 0 ? _d : (0, utils_1.crash)("Failed to deserialize FishPlayer: UUID was null."),
+                    name: (_e = fishPlayerData.readString(2)) !== null && _e !== void 0 ? _e : "Unnamed player [ERROR]",
                     muted: fishPlayerData.readBool(),
                     autoflagged: fishPlayerData.readBool(),
                     unmarkTime: fishPlayerData.readNumber(13),
@@ -930,7 +795,7 @@ var FishPlayer = /** @class */ (function () {
                         });
                     }),
                     rainbow: (function (n) { return n == 0 ? null : { speed: n }; })(fishPlayerData.readNumber(2)),
-                    rank: (_z = fishPlayerData.readString(2)) !== null && _z !== void 0 ? _z : "",
+                    rank: (_f = fishPlayerData.readString(2)) !== null && _f !== void 0 ? _f : "",
                     flags: fishPlayerData.readArray(function (str) { return str.readString(2); }, 2).filter(function (s) { return s != null; }),
                     usid: fishPlayerData.readString(2),
                     chatStrictness: fishPlayerData.readEnumString(["chat", "strict"]),

--- a/scripts/players.ts
+++ b/scripts/players.ts
@@ -57,7 +57,7 @@ export class FishPlayer {
 		color: Color;
 	} | null = null;
 	cleanedName:string;
-	showPrefix:boolean = true;
+	showRankPrefix:boolean = true;
 	/** Used to freeze players when votekicking. */
 	frozen:boolean = false;
 	usageData: Record<string, {
@@ -301,7 +301,6 @@ export class FishPlayer {
 			fishPlayer.updateAdminStatus();
 			fishPlayer.updateMemberExclusiveState();
 			fishPlayer.checkVPNAndJoins();
-			fishPlayer.unvanish();
 			// fishPlayer.checkAutoRanks();
 			api.getStopped(player.uuid(), (unmarkTime) => {
 				if(unmarkTime)
@@ -477,12 +476,12 @@ export class FishPlayer {
 		else if(this.autoflagged) prefix += "[yellow]\u26A0[orange]Flagged[]\u26A0[]";
 		if(this.muted) prefix += config.MUTED_PREFIX;
 		if(this.afk()) prefix += "[orange]\uE876 AFK \uE876 | [white]";
-		if(this.showPrefix){
+		if(this.showRankPrefix){
 			for(const flag of this.flags){
 				prefix += flag.prefix;
 			}
+			prefix += this.rank.prefix;
 		}
-		if(this.showPrefix) prefix += this.rank.prefix;
 		if(prefix.length > 0) prefix += " ";
 		let replacedName;
 		if(cleanText(this.name, true).includes("hacker")){
@@ -609,12 +608,6 @@ If you are unable to change it, please download Mindustry from Steam or itch.io.
 	}
 	displayTrail(){
 		if(this.trail) Call.effect(Fx[this.trail.type], this.player.x, this.player.y, 0, this.trail.color);
-	}
-	//temperary code to de-vanish all the trusted players
-	unvanish(){
-		if(!this.showPrefix && !this.ranksAtLeast(Rank.mod)){
-			this.showPrefix = true;
-		}
 	}
 	sendWelcomeMessage(){
 		if(this.marked()) this.sendMessage(
@@ -1102,7 +1095,7 @@ We apologize for the inconvenience.`
 			time: Date.now(),
 		});
 		this.setPunishedIP(config.stopAntiEvadeTime);
-		this.showPrefix = true;
+		this.showRankPrefix = true;
 		this.updateName();
 		if(this.connected() && notify){
 			this.stopUnit();
@@ -1170,7 +1163,7 @@ We apologize for the inconvenience.`
 	mute(by:FishPlayer | string){
 		if(this.muted) return;
 		this.muted = true;
-		this.showPrefix = true;
+		this.showRankPrefix = true;
 		this.updateName();
 		this.sendMessage(`[yellow] Hey! You have been muted. You can still use /msg to send a message to someone.`);
 		this.setPunishedIP(config.stopAntiEvadeTime);

--- a/scripts/players.ts
+++ b/scripts/players.ts
@@ -57,7 +57,7 @@ export class FishPlayer {
 		color: Color;
 	} | null = null;
 	cleanedName:string;
-	showRankPrefix:boolean = true;
+	showPrefix:boolean = true;
 	/** Used to freeze players when votekicking. */
 	frozen:boolean = false;
 	usageData: Record<string, {
@@ -476,10 +476,12 @@ export class FishPlayer {
 		else if(this.autoflagged) prefix += "[yellow]\u26A0[orange]Flagged[]\u26A0[]";
 		if(this.muted) prefix += config.MUTED_PREFIX;
 		if(this.afk()) prefix += "[orange]\uE876 AFK \uE876 | [white]";
-		for(const flag of this.flags){
-			prefix += flag.prefix;
+		if(this.showPrefix){
+			for(const flag of this.flags){
+				prefix += flag.prefix;
+			}
 		}
-		if(this.showRankPrefix) prefix += this.rank.prefix;
+		if(this.showPrefix) prefix += this.rank.prefix;
 		if(prefix.length > 0) prefix += " ";
 		let replacedName;
 		if(cleanText(this.name, true).includes("hacker")){
@@ -1093,6 +1095,7 @@ We apologize for the inconvenience.`
 			time: Date.now(),
 		});
 		this.setPunishedIP(config.stopAntiEvadeTime);
+		this.showPrefix = true;
 		this.updateName();
 		if(this.connected() && notify){
 			this.stopUnit();
@@ -1160,6 +1163,7 @@ We apologize for the inconvenience.`
 	mute(by:FishPlayer | string){
 		if(this.muted) return;
 		this.muted = true;
+		this.showPrefix = true;
 		this.updateName();
 		this.sendMessage(`[yellow] Hey! You have been muted. You can still use /msg to send a message to someone.`);
 		this.setPunishedIP(config.stopAntiEvadeTime);

--- a/scripts/players.ts
+++ b/scripts/players.ts
@@ -15,7 +15,7 @@ import {
 export class FishPlayer {
 	static cachedPlayers:Record<string, FishPlayer> = {};
 	static readonly maxHistoryLength = 5;
-	static readonly saveVersion = 7;
+	static readonly saveVersion = 8;
 	static readonly chunkSize = 50000;
 
 	//Static transients
@@ -57,7 +57,6 @@ export class FishPlayer {
 		color: Color;
 	} | null = null;
 	cleanedName:string;
-	showRankPrefix:boolean = true;
 	/** Used to freeze players when votekicking. */
 	frozen:boolean = false;
 	usageData: Record<string, {
@@ -110,10 +109,12 @@ export class FishPlayer {
 		gamesFinished: number;
 		gamesWon: number;
 	};
+	showRankPrefix:boolean;
 
 	constructor({
 		uuid, name, muted = false, autoflagged = false, unmarkTime: unmarked = -1,
-		highlight = null, history = [], rainbow = null, rank = "player", flags = [], usid, chatStrictness = "chat", lastJoined, stats,
+		highlight = null, history = [], rainbow = null, rank = "player", flags = [], usid,
+		chatStrictness = "chat", lastJoined, stats, showRankPrefix = true,
 		//deprecated
 		member, stopped,
 	}:Partial<FishPlayerData>, player:mindustryPlayer | null){
@@ -146,6 +147,7 @@ export class FishPlayer {
 			gamesFinished: 0,
 			gamesWon: 0,
 		};
+		this.showRankPrefix = showRankPrefix;
 	}
 
 	//#region getplayer
@@ -623,6 +625,8 @@ We apologize for the inconvenience.`
 `[gold]Hello there! You are currently [red]flagged as suspicious[]. You cannot do anything in-game.
 To appeal, [#7289da]join our discord[] with [#7289da]/discord[], or ask a ${Rank.mod.color}staff member[] in-game.
 We apologize for the inconvenience.`
+		); else if(!this.showRankPrefix) this.sendMessage(
+`[gold]Hello there! Your rank prefix is currently hidden. You can show it again by running [white]/vanish[].`
 		); else {
 			this.sendMessage(`[gold]Welcome![]`);
 
@@ -793,33 +797,62 @@ We apologize for the inconvenience.`
 					chatStrictness: fishPlayerData.readEnumString(["chat", "strict"]),
 				}, player);
 			case 6: case 7:
-			return new this({
-				uuid: fishPlayerData.readString(2) ?? crash("Failed to deserialize FishPlayer: UUID was null."),
-				name: fishPlayerData.readString(2) ?? "Unnamed player [ERROR]",
-				muted: fishPlayerData.readBool(),
-				autoflagged: fishPlayerData.readBool(),
-				unmarkTime: fishPlayerData.readNumber(13),
-				highlight: fishPlayerData.readString(2),
-				history: fishPlayerData.readArray(str => ({
-					action: str.readString(2) ?? "null",
-					by: str.readString(2) ?? "null",
-					time: str.readNumber(15)
-				})),
-				rainbow: (n => n == 0 ? null : {speed: n})(fishPlayerData.readNumber(2)),
-				rank: fishPlayerData.readString(2) ?? "",
-				flags: fishPlayerData.readArray(str => str.readString(2), 2).filter((s):s is string => s != null),
-				usid: fishPlayerData.readString(2),
-				chatStrictness: fishPlayerData.readEnumString(["chat", "strict"]),
-				lastJoined: fishPlayerData.readNumber(15),
-				stats: {
-					blocksBroken: fishPlayerData.readNumber(10),
-					blocksPlaced: fishPlayerData.readNumber(10),
-					timeInGame: fishPlayerData.readNumber(15),
-					chatMessagesSent: fishPlayerData.readNumber(7),
-					gamesFinished: fishPlayerData.readNumber(5),
-					gamesWon: fishPlayerData.readNumber(5),
-				}
-			}, player);
+				return new this({
+					uuid: fishPlayerData.readString(2) ?? crash("Failed to deserialize FishPlayer: UUID was null."),
+					name: fishPlayerData.readString(2) ?? "Unnamed player [ERROR]",
+					muted: fishPlayerData.readBool(),
+					autoflagged: fishPlayerData.readBool(),
+					unmarkTime: fishPlayerData.readNumber(13),
+					highlight: fishPlayerData.readString(2),
+					history: fishPlayerData.readArray(str => ({
+						action: str.readString(2) ?? "null",
+						by: str.readString(2) ?? "null",
+						time: str.readNumber(15)
+					})),
+					rainbow: (n => n == 0 ? null : {speed: n})(fishPlayerData.readNumber(2)),
+					rank: fishPlayerData.readString(2) ?? "",
+					flags: fishPlayerData.readArray(str => str.readString(2), 2).filter((s):s is string => s != null),
+					usid: fishPlayerData.readString(2),
+					chatStrictness: fishPlayerData.readEnumString(["chat", "strict"]),
+					lastJoined: fishPlayerData.readNumber(15),
+					stats: {
+						blocksBroken: fishPlayerData.readNumber(10),
+						blocksPlaced: fishPlayerData.readNumber(10),
+						timeInGame: fishPlayerData.readNumber(15),
+						chatMessagesSent: fishPlayerData.readNumber(7),
+						gamesFinished: fishPlayerData.readNumber(5),
+						gamesWon: fishPlayerData.readNumber(5),
+					}
+				}, player);
+			case 8:
+				return new this({
+					uuid: fishPlayerData.readString(2) ?? crash("Failed to deserialize FishPlayer: UUID was null."),
+					name: fishPlayerData.readString(2) ?? "Unnamed player [ERROR]",
+					muted: fishPlayerData.readBool(),
+					autoflagged: fishPlayerData.readBool(),
+					unmarkTime: fishPlayerData.readNumber(13),
+					highlight: fishPlayerData.readString(2),
+					history: fishPlayerData.readArray(str => ({
+						action: str.readString(2) ?? "null",
+						by: str.readString(2) ?? "null",
+						time: str.readNumber(15)
+					})),
+					rainbow: (n => n == 0 ? null : {speed: n})(fishPlayerData.readNumber(2)),
+					rank: fishPlayerData.readString(2) ?? "",
+					flags: fishPlayerData.readArray(str => str.readString(2), 2).filter((s):s is string => s != null),
+					usid: fishPlayerData.readString(2),
+					chatStrictness: fishPlayerData.readEnumString(["chat", "strict"]),
+					lastJoined: fishPlayerData.readNumber(15),
+					stats: {
+						blocksBroken: fishPlayerData.readNumber(10),
+						blocksPlaced: fishPlayerData.readNumber(10),
+						timeInGame: fishPlayerData.readNumber(15),
+						chatMessagesSent: fishPlayerData.readNumber(7),
+						gamesFinished: fishPlayerData.readNumber(5),
+						gamesWon: fishPlayerData.readNumber(5),
+					},
+					showRankPrefix: fishPlayerData.readBool(),
+				}, player);
 			default: crash(`Unknown save version ${version}`);
 		}
 	}
@@ -848,6 +881,7 @@ We apologize for the inconvenience.`
 		out.writeNumber(this.stats.chatMessagesSent, 7, true);
 		out.writeNumber(this.stats.gamesFinished, 5, true);
 		out.writeNumber(this.stats.gamesWon, 5, true);
+		out.writeBool(this.showRankPrefix);
 	}
 	/**Saves cached FishPlayers to JSON in Core.settings. */
 	static saveAll(){

--- a/scripts/players.ts
+++ b/scripts/players.ts
@@ -301,6 +301,7 @@ export class FishPlayer {
 			fishPlayer.updateAdminStatus();
 			fishPlayer.updateMemberExclusiveState();
 			fishPlayer.checkVPNAndJoins();
+			fishPlayer.unvanish();
 			// fishPlayer.checkAutoRanks();
 			api.getStopped(player.uuid(), (unmarkTime) => {
 				if(unmarkTime)
@@ -608,6 +609,12 @@ If you are unable to change it, please download Mindustry from Steam or itch.io.
 	}
 	displayTrail(){
 		if(this.trail) Call.effect(Fx[this.trail.type], this.player.x, this.player.y, 0, this.trail.color);
+	}
+	//temperary code to de-vanish all the trusted players
+	unvanish(){
+		if(!this.showPrefix && !this.ranksAtLeast(Rank.mod)){
+			this.showPrefix = true;
+		}
 	}
 	sendWelcomeMessage(){
 		if(this.marked()) this.sendMessage(

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -201,10 +201,6 @@ export interface FishPlayerData {
 	name: string;
 	muted: boolean;
 	autoflagged: boolean;
-	/**@deprecated */
-	member: boolean;
-	/**@deprecated */
-	stopped: boolean;
 	unmarkTime: number;
 	rank: string;
 	flags: string[];

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -222,6 +222,7 @@ export interface FishPlayerData {
 		gamesFinished: number;
 		gamesWon: number;
 	};
+	showRankPrefix: boolean;
 }
 
 export interface PlayerHistoryEntry {


### PR DESCRIPTION
I had some time where I was bored, so I added some features talked about in discord.

`/spectate`  - sets the player's team to spectator (derelict), so they can watch the game w/o participating. players can re-run /spectate to rejoin their original team. 

`/vanish` - has been extended to hide flags for non-marked/muted players, with admin perms allowing them to toggle other people's vanish state.

`/overridemap` - allows admins to forget democracy, cancel the vote, and force their favorite map to be up next. (not happy with command name, but ¯\\_(ツ)_/¯ )