### PR TITLE
Bulk effects rank (Now split from /nextmap)

### DIFF
--- a/build/scripts/commands.js
+++ b/build/scripts/commands.js
@@ -103,7 +103,7 @@ var Perm = /** @class */ (function () {
     Perm.seeErrorMessages = new Perm("seeErrorMessages", "admin");
     Perm.viewUUIDs = new Perm("viewUUIDs", "admin");
     Perm.blockTrolling = new Perm("blockTrolling", function (fishP) { return fishP.rank === ranks_1.Rank.pi; });
-    Perm.bulkLabelPacket = new Perm("bulkLabelPacket", function (fishP) { return ((fishP.hasFlag("developer") || fishP.hasFlag("effects") || fishP.hasFlag("member")) && !fishP.stelled()) || fishP.ranksAtLeast("mod"); });
+    Perm.bulkLabelPacket = new Perm("bulkLabelPacket", function (fishP) { return ((fishP.hasFlag("developer") || fishP.hasFlag("illusionist") || fishP.hasFlag("member")) && !fishP.stelled()) || fishP.ranksAtLeast("mod"); });
     Perm.visualEffects = new Perm("visualEffects", function (fishP) { return !fishP.stelled() || fishP.ranksAtLeast("mod"); });
     Perm.bypassVoteFreeze = new Perm("bypassVoteFreeze", "trusted");
     Perm.bypassVotekick = new Perm("bypassVotekick", "mod");

--- a/build/scripts/commands.js
+++ b/build/scripts/commands.js
@@ -103,7 +103,7 @@ var Perm = /** @class */ (function () {
     Perm.seeErrorMessages = new Perm("seeErrorMessages", "admin");
     Perm.viewUUIDs = new Perm("viewUUIDs", "admin");
     Perm.blockTrolling = new Perm("blockTrolling", function (fishP) { return fishP.rank === ranks_1.Rank.pi; });
-    Perm.bulkLabelPacket = new Perm("bulkLabelPacket", function (fishP) { return ((fishP.hasFlag("developer") || fishP.hasFlag("member")) && !fishP.stelled()) || fishP.ranksAtLeast("mod"); });
+    Perm.bulkLabelPacket = new Perm("bulkLabelPacket", function (fishP) { return ((fishP.hasFlag("developer") || fishP.hasFlag("effects") || fishP.hasFlag("member")) && !fishP.stelled()) || fishP.ranksAtLeast("mod"); });
     Perm.visualEffects = new Perm("visualEffects", function (fishP) { return !fishP.stelled() || fishP.ranksAtLeast("mod"); });
     Perm.bypassVoteFreeze = new Perm("bypassVoteFreeze", "trusted");
     Perm.bypassVotekick = new Perm("bypassVotekick", "mod");

--- a/build/scripts/packetHandlers.js
+++ b/build/scripts/packetHandlers.js
@@ -6,7 +6,7 @@ var commands_1 = require("./commands");
 var players_1 = require("./players");
 //some much needed restrictions
 /** point in which effects will refuse to render */
-var MIN_EFFECT_TPS = 10;
+var MIN_EFFECT_TPS = 20;
 /** maximum duration for user-created labels (seconds) */
 var MAX_LABEL_TIME = 30;
 //info tracker

--- a/build/scripts/packetHandlers.js
+++ b/build/scripts/packetHandlers.js
@@ -153,16 +153,16 @@ exports.commands = (0, commands_1.commandList)({
             var output = _a.output;
             var outputLines = [];
             if (lastAccessedLabel && lastLabel) {
-                outputLines.push("".concat(lastAccessedLabel.name, " created label \"").concat(lastLabel, "\"."));
+                outputLines.push("".concat(lastAccessedLabel.name, "[] created label \"").concat(lastLabel, "\"."));
             }
             if (lastAccessedBulkLabel) {
-                outputLines.push("".concat(lastAccessedBulkLabel.name, " last used the bulk label effect."));
+                outputLines.push("".concat(lastAccessedBulkLabel.name, "[] last used the bulk label effect."));
             }
             if (lastAccessedLine) {
-                outputLines.push("".concat(lastAccessedLine.name, " last used the line effect."));
+                outputLines.push("".concat(lastAccessedLine.name, "[] last used the line effect."));
             }
             if (lastAccessedBulkLine) {
-                outputLines.push("".concat(lastAccessedBulkLine.name, " last used the bulk line effect."));
+                outputLines.push("".concat(lastAccessedBulkLine.name, "[] last used the bulk line effect."));
             }
             output(outputLines.length > 0 ? outputLines.join('\n') : 'No packet handlers have been accessed yet.');
         }

--- a/build/scripts/packetHandlers.js
+++ b/build/scripts/packetHandlers.js
@@ -5,8 +5,10 @@ exports.loadPacketHandlers = loadPacketHandlers;
 var commands_1 = require("./commands");
 var players_1 = require("./players");
 //some much needed restrictions
-var MIN_EFFECT_TPS = 10; // point in which effects will refuse to render
-var MAX_LABEL_TIME = 30; // maximum duration for user-created labels (seconds)
+/** point in which effects will refuse to render */
+var MIN_EFFECT_TPS = 10;
+/** maximum duration for user-created labels (seconds) */
+var MAX_LABEL_TIME = 30;
 //info tracker
 var lastLabel = '';
 var lastAccessedBulkLabel = null;
@@ -32,12 +34,12 @@ function loadPacketHandlers() {
     //labels
     //fmt: "content,duration,x,y"
     Vars.netServer.addPacketHandler('label', function (player, content) {
-        if (Core.graphics.getFramesPerSecond() < MIN_EFFECT_TPS) {
-            player.sendMessage(lowTPSError);
-            return;
-        }
+        var p = players_1.FishPlayer.get(player);
         try {
-            var p = players_1.FishPlayer.get(player);
+            if (Core.graphics.getFramesPerSecond() < MIN_EFFECT_TPS) {
+                p.sendMessage(lowTPSError, 1000);
+                return;
+            }
             if (!p.hasPerm("visualEffects")) {
                 p.sendMessage(noPermissionText, 1000);
                 return;
@@ -45,19 +47,17 @@ function loadPacketHandlers() {
             lastAccessedLabel = p;
             handleLabel(player, content, true);
         }
-        catch (e) {
-            //TEMP FOR DEBUGGING: REMOVE L8R
-            //Log.err(e as Error);
-            player.sendMessage(procError);
+        catch (_a) {
+            p.sendMessage(procError, 1000);
         }
     });
     Vars.netServer.addPacketHandler('bulkLabel', function (player, content) {
-        if (Core.graphics.getFramesPerSecond() < MIN_EFFECT_TPS) {
-            player.sendMessage(lowTPSError);
-            return;
-        }
         var p = players_1.FishPlayer.get(player);
         try {
+            if (Core.graphics.getFramesPerSecond() < MIN_EFFECT_TPS) {
+                p.sendMessage(lowTPSError, 1000);
+                return;
+            }
             if (!p.hasPerm('bulkLabelPacket')) {
                 p.sendMessage(noPermissionText, 1000);
                 return;
@@ -102,20 +102,18 @@ function loadPacketHandlers() {
                     return;
             }
         }
-        catch (e) {
-            //TEMP FOR DEBUGGING: REMOVE L8R
-            //Log.err(e as Error);
+        catch (_a) {
             p.sendMessage(procError, 1000);
         }
     });
     //lines
     Vars.netServer.addPacketHandler('lineEffect', function (player, content) {
-        if (Core.graphics.getFramesPerSecond() < MIN_EFFECT_TPS) {
-            player.sendMessage(lowTPSError);
-            return;
-        }
         var p = players_1.FishPlayer.get(player);
         try {
+            if (Core.graphics.getFramesPerSecond() < MIN_EFFECT_TPS) {
+                p.sendMessage(lowTPSError, 1000);
+                return;
+            }
             if (!p.hasPerm("visualEffects")) {
                 p.sendMessage(noPermissionText, 1000);
                 return;
@@ -124,24 +122,22 @@ function loadPacketHandlers() {
                 return;
             lastAccessedLine = p;
         }
-        catch (e) {
-            //TEMP FOR DEBUGGING: REMOVE L8R
-            //Log.err(e as Error);
+        catch (_a) {
             p.sendMessage(procError, 1000);
         }
     });
     //this is the silas effect but it's way too real
     Vars.netServer.addPacketHandler('bulkLineEffect', function (player, content) {
+        var p = players_1.FishPlayer.get(player);
         if (Core.graphics.getFramesPerSecond() < MIN_EFFECT_TPS) {
-            player.sendMessage(lowTPSError);
+            p.sendMessage(lowTPSError, 1000);
             return;
         }
-        var p = players_1.FishPlayer.get(player);
+        if (!p.hasPerm('bulkLabelPacket')) {
+            p.sendMessage(noPermissionText, 1000);
+            return;
+        }
         try {
-            if (!p.hasPerm('bulkLabelPacket')) {
-                p.sendMessage(noPermissionText, 1000);
-                return;
-            }
             var lines = content.split(bulkSeparator);
             if (lines.length > bulkLimit) {
                 p.sendMessage(tooLongText, 1000);
@@ -156,9 +152,7 @@ function loadPacketHandlers() {
             }
             lastAccessedBulkLine = p;
         }
-        catch (e) {
-            //TEMP FOR DEBUGGING: REMOVE L8R
-            //Log.err(e as Error);
+        catch (_a) {
             p.sendMessage(procError, 1000);
         }
     });
@@ -227,7 +221,6 @@ function handleLabel(player, content, isSingle) {
     if (isSingle) {
         lastLabel = message;
     }
-    //do not mind me, just dropping this quick check in here
     var duration = Number(parts[0]);
     if (Number.isNaN(duration) || duration > MAX_LABEL_TIME) {
         player.sendMessage(invalidReq);
@@ -243,7 +236,7 @@ function handleLabel(player, content, isSingle) {
     tmpLabelPacket.duration = Number(parts[0]);
     tmpLabelPacket.worldx = Number(parts[1]);
     tmpLabelPacket.worldy = Number(parts[2]);
-    Vars.net.send(tmpLabelPacket, true); //maybe do false
+    Vars.net.send(tmpLabelPacket, false);
     return true;
 }
 function handleLine(content, player) {
@@ -262,7 +255,7 @@ function handleLine(content, player) {
     );*/
     tmpLinePacket.x = Number(parts[0]);
     tmpLinePacket.y = Number(parts[1]);
-    Vars.net.send(tmpLinePacket, false); //could do true for reliable but prob too laggy (?)
+    Vars.net.send(tmpLinePacket, false);
     return true;
 }
 function bulkInfoMsg(messages, conn) {

--- a/build/scripts/packetHandlers.js
+++ b/build/scripts/packetHandlers.js
@@ -4,6 +4,9 @@ exports.commands = void 0;
 exports.loadPacketHandlers = loadPacketHandlers;
 var commands_1 = require("./commands");
 var players_1 = require("./players");
+//some much needed restrictions
+var MIN_EFFECT_TPS = 10; // point in which effects will refuse to render
+var MAX_LABEL_TIME = 30; // maximum duration for user-created labels (seconds)
 //info tracker
 var lastLabel = '';
 var lastAccessedBulkLabel = null;
@@ -17,6 +20,7 @@ var tooLongText = '[red]Bulk content length exceeded, please use fewer effects.'
 var bulkSeparator = '|';
 var procError = '[red]An error occured while processing your request.';
 var invalidReq = '[red]Invalid request. Please consult the documentation.';
+var lowTPSError = '[red]Low server TPS, skipping request.';
 var tmpLinePacket = new EffectCallPacket2();
 var tmpLabelPacket = new LabelReliableCallPacket();
 function loadPacketHandlers() {
@@ -28,6 +32,10 @@ function loadPacketHandlers() {
     //labels
     //fmt: "content,duration,x,y"
     Vars.netServer.addPacketHandler('label', function (player, content) {
+        if (Core.graphics.getFramesPerSecond() < MIN_EFFECT_TPS) {
+            player.sendMessage(lowTPSError);
+            return;
+        }
         try {
             var p = players_1.FishPlayer.get(player);
             if (!p.hasPerm("visualEffects")) {
@@ -44,6 +52,10 @@ function loadPacketHandlers() {
         }
     });
     Vars.netServer.addPacketHandler('bulkLabel', function (player, content) {
+        if (Core.graphics.getFramesPerSecond() < MIN_EFFECT_TPS) {
+            player.sendMessage(lowTPSError);
+            return;
+        }
         var p = players_1.FishPlayer.get(player);
         try {
             if (!p.hasPerm('bulkLabelPacket')) {
@@ -98,6 +110,10 @@ function loadPacketHandlers() {
     });
     //lines
     Vars.netServer.addPacketHandler('lineEffect', function (player, content) {
+        if (Core.graphics.getFramesPerSecond() < MIN_EFFECT_TPS) {
+            player.sendMessage(lowTPSError);
+            return;
+        }
         var p = players_1.FishPlayer.get(player);
         try {
             if (!p.hasPerm("visualEffects")) {
@@ -116,6 +132,10 @@ function loadPacketHandlers() {
     });
     //this is the silas effect but it's way too real
     Vars.netServer.addPacketHandler('bulkLineEffect', function (player, content) {
+        if (Core.graphics.getFramesPerSecond() < MIN_EFFECT_TPS) {
+            player.sendMessage(lowTPSError);
+            return;
+        }
         var p = players_1.FishPlayer.get(player);
         try {
             if (!p.hasPerm('bulkLabelPacket')) {
@@ -173,25 +193,7 @@ exports.commands = (0, commands_1.commandList)({
         perm: commands_1.Perm.none,
         handler: function (_a) {
             var sender = _a.sender, output = _a.output;
-            var responseLines = [];
-            var canBulk = sender.hasPerm('bulkLabelPacket');
-            responseLines.push('Line effect: "lineEffect", "x0,y0,x1,y1,hexColor" (for example "20.7,19.3,50.4,28.9,#FF0000")\n');
-            if (canBulk)
-                responseLines.push('Bulk line effect: "bulkLineEffect", equivalent to multiple lineEffect packets, with every line separated by a \'|\' symbol.\n');
-            responseLines.push('Label effect: "label", "content,duration,x,y" (for example ""Hi!",10,20,28")\n');
-            if (canBulk)
-                responseLines.push('Bulk label effect: "bulkLabel", equivalent to multiple label packets, with every label separated by a \'|\' symbol.\n');
-            responseLines.push('Use "Call.serverPacketReliable" to send these.');
-            responseLines.push('You need to multiply world coordinates by Vars.tilesize (8) for things to work properly. This is a relic from the v3 days where every tile was 8 pixels.');
-            responseLines.push('Keep in mind there\'s a packet spam limit. Use at your own risk.');
-            responseLines.push(''); //empty line
-            //credit
-            responseLines.push('These packet handlers and everything related to them were made by [green]frog[white].');
-            responseLines.push('"The code style when submitted was beyond drunk... but it worked... barely"\n    -BalaM314');
-            responseLines.push('"worst error handling i have ever seen, why kick the player???"\n    -ASimpleBeginner');
-            responseLines.push('Most of the code was rewritten in 2024 by [#6e00fb]D[#9e15de]a[#cd29c2]r[#fd3ea5]t[white].');
-            //bulkInfoMsg(responseLines, sender.player.con as NetConnection);
-            output(responseLines.join('\n'));
+            output("\t\t\t\t\t        [blue]FISH[white] Packet Handler Docs\n[white]Usage:[accent]\n\t- Run the javascript function \"Call.serverPacketReliable()\" to send these. (!js in foos)\n\t- You need to multiply world coordinates by Vars.tilesize (8) for things to work properly. This is a relic from the v3 days where every tile was 8 pixels.\n\n[white]Packet types[accent]:\n\t- Line effect: \"lineEffect\", \"x0,y0,x1,y1,hexColor\" (for example \"20.7,19.3,50.4,28.9,#FF0000\")\n\t- Bulk line effect: \"bulkLineEffect\", equivalent to multiple lineEffect packets, with every line separated by a '|' symbol.\n\t- Label effect: \"label\", \"content,duration,x,y\" (for example \"\"Hi!\",10,20,28\")\n\t- Bulk label effect: \"bulkLabel\", equivalent to multiple label packets, with every label separated by a '|' symbol.\n\n[white]Limitations[accent]:\n\t- You ".concat((sender.hasPerm('bulkLabelPacket') ? ("[green]have been granted[accent]") : ("[red]do not[accent]")), " have access to bulk effects.\n\t- Effects will no longer be drawn at ").concat(MIN_EFFECT_TPS, " for server preformance.\n\t- Labels cannot last longer than ").concat(MAX_LABEL_TIME, " seconds.\n\t- There is a set ratelimit for sending packets, be careful ...\n\n[white]Starter Example[accent]:\n\n\tTo place a label saying \"hello\" at (0,0);\n\tFoos users : [lightgray]!js Call.serverPacketReliable(\"label\", [\"\\\"hello\\\"\", 10, 0, 0].join(\",\"))[accent]\n\tnewConsole users :  [lightgrey]Call.serverPacketReliable(\"label\", [\"hello\", 10, 0, 10].join(\",\"))[accent]\n\n[white]Comments and Credits[accent]:\n\t- 'These packet handlers and everything related to them were made by [green]frog[accent].\n\t- 'The code style when submitted was beyond drunk... but it worked... barely' -BalaM314\n\t- \"worst error handling i have ever seen, why kick the player???\" -ASimpleBeginner'\n\t- Most of the code was rewritten in 2024 by [#6e00fb]D[#9e15de]a[#cd29c2]r[#fd3ea5]t[accent].'\n\t- Small tweaks by [#00cf]s[#00bf]w[#009f]a[#007f]m[#005f]p[accent]"));
         }
     }
 });
@@ -224,6 +226,12 @@ function handleLabel(player, content, isSingle) {
     }
     if (isSingle) {
         lastLabel = message;
+    }
+    //do not mind me, just dropping this quick check in here
+    var duration = Number(parts[0]);
+    if (Number.isNaN(duration) || duration > MAX_LABEL_TIME) {
+        player.sendMessage(invalidReq);
+        return false;
     }
     /*Call.labelReliable(
         message,          //message

--- a/build/scripts/packetHandlers.js
+++ b/build/scripts/packetHandlers.js
@@ -173,16 +173,16 @@ exports.commands = (0, commands_1.commandList)({
             var output = _a.output;
             var outputLines = [];
             if (lastAccessedLabel && lastLabel) {
-                outputLines.push("".concat(lastAccessedLabel.name, "[] created label \"").concat(lastLabel, "\"."));
+                outputLines.push("".concat(lastAccessedLabel.name, "[white] created label \"").concat(lastLabel, "\"."));
             }
             if (lastAccessedBulkLabel) {
-                outputLines.push("".concat(lastAccessedBulkLabel.name, "[] last used the bulk label effect."));
+                outputLines.push("".concat(lastAccessedBulkLabel.name, "[white] last used the bulk label effect."));
             }
             if (lastAccessedLine) {
-                outputLines.push("".concat(lastAccessedLine.name, "[] last used the line effect."));
+                outputLines.push("".concat(lastAccessedLine.name, "[white] last used the line effect."));
             }
             if (lastAccessedBulkLine) {
-                outputLines.push("".concat(lastAccessedBulkLine.name, "[] last used the bulk line effect."));
+                outputLines.push("".concat(lastAccessedBulkLine.name, "[white] last used the bulk line effect."));
             }
             output(outputLines.length > 0 ? outputLines.join('\n') : 'No packet handlers have been accessed yet.');
         }
@@ -193,7 +193,7 @@ exports.commands = (0, commands_1.commandList)({
         perm: commands_1.Perm.none,
         handler: function (_a) {
             var sender = _a.sender, output = _a.output;
-            output("\t\t\t\t\t        [blue]FISH[white] Packet Handler Docs\n[white]Usage:[accent]\n\t- Run the javascript function \"Call.serverPacketReliable()\" to send these. (!js in foos)\n\t- You need to multiply world coordinates by Vars.tilesize (8) for things to work properly. This is a relic from the v3 days where every tile was 8 pixels.\n\n[white]Packet types[accent]:\n\t- Line effect: \"lineEffect\", \"x0,y0,x1,y1,hexColor\" (for example \"20.7,19.3,50.4,28.9,#FF0000\")\n\t- Bulk line effect: \"bulkLineEffect\", equivalent to multiple lineEffect packets, with every line separated by a '|' symbol.\n\t- Label effect: \"label\", \"content,duration,x,y\" (for example \"\"Hi!\",10,20,28\")\n\t- Bulk label effect: \"bulkLabel\", equivalent to multiple label packets, with every label separated by a '|' symbol.\n\n[white]Limitations[accent]:\n\t- You ".concat((sender.hasPerm('bulkLabelPacket') ? ("[green]have been granted[accent]") : ("[red]do not[accent]")), " have access to bulk effects.\n\t- Effects will no longer be drawn at ").concat(MIN_EFFECT_TPS, " for server preformance.\n\t- Labels cannot last longer than ").concat(MAX_LABEL_TIME, " seconds.\n\t- There is a set ratelimit for sending packets, be careful ...\n\n[white]Starter Example[accent]:\n\n\tTo place a label saying \"hello\" at (0,0);\n\tFoos users : [lightgray]!js Call.serverPacketReliable(\"label\", [\"\\\"hello\\\"\", 10, 0, 0].join(\",\"))[accent]\n\tnewConsole users :  [lightgrey]Call.serverPacketReliable(\"label\", [\"hello\", 10, 0, 10].join(\",\"))[accent]\n\n[white]Comments and Credits[accent]:\n\t- 'These packet handlers and everything related to them were made by [green]frog[accent].\n\t- 'The code style when submitted was beyond drunk... but it worked... barely' -BalaM314\n\t- \"worst error handling i have ever seen, why kick the player???\" -ASimpleBeginner'\n\t- Most of the code was rewritten in 2024 by [#6e00fb]D[#9e15de]a[#cd29c2]r[#fd3ea5]t[accent].'\n\t- Small tweaks by [#00cf]s[#00bf]w[#009f]a[#007f]m[#005f]p[accent]"));
+            output("\t\t\t\t\t        [blue]FISH[white] Packet Handler Docs\n[white]Usage:[accent]\n\t- Run the javascript function \"Call.serverPacketReliable()\" to send these. (!js in foos)\n\t- You need to multiply world coordinates by Vars.tilesize (8) for things to work properly. This is a relic from the v3 days where every tile was 8 pixels.\n\n[white]Packet types[accent]:\n\t- Line effect: \"lineEffect\", \"x0,y0,x1,y1,hexColor\" (for example \"20.7,19.3,50.4,28.9,#FF0000\")\n\t- Bulk line effect: \"bulkLineEffect\", equivalent to multiple lineEffect packets, with every line separated by a '|' symbol.\n\t- Label effect: \"label\", \"content,duration,x,y\" (for example \"\"Hi!\",10,20,28\")\n\t- Bulk label effect: \"bulkLabel\", equivalent to multiple label packets, with every label separated by a '|' symbol.\n\n[white]Limitations[accent]:\n\t- You ".concat((sender.hasPerm('bulkLabelPacket') ? ("[green]have been granted[accent]") : ("[red]do not have[accent]")), " access to bulk effects.\n\t- Effects will no longer be drawn at ").concat(MIN_EFFECT_TPS, " for server preformance.\n\t- Labels cannot last longer than ").concat(MAX_LABEL_TIME, " seconds.\n\t- There is a set ratelimit for sending packets, be careful ...\n\n[white]Starter Example[accent]:\n\n\tTo place a label saying \"hello\" at (0,0);\n\tFoos users : [lightgray]!js Call.serverPacketReliable(\"label\", [\"\\\"hello\\\"\", 10, 0, 0].join(\",\"))[accent]\n\tnewConsole users :  [lightgrey]Call.serverPacketReliable(\"label\", [\"hello\", 10, 0, 10].join(\",\"))[accent]\n\n[white]Comments and Credits[accent]:\n\t- 'These packet handlers and everything related to them were made by [green]frog[accent].\n\t- 'The code style when submitted was beyond drunk... but it worked... barely' -BalaM314\n\t- \"worst error handling i have ever seen, why kick the player???\" -ASimpleBeginner'\n\t- Most of the code was rewritten in 2024 by [#6e00fb]D[#9e15de]a[#cd29c2]r[#fd3ea5]t[accent].'\n\t- Small tweaks by [#00cf]s[#00bf]w[#009f]a[#007f]m[#005f]p[accent]"));
         }
     }
 });

--- a/build/scripts/ranks.js
+++ b/build/scripts/ranks.js
@@ -73,7 +73,7 @@ var RoleFlag = /** @class */ (function () {
     RoleFlag.flags = {};
     RoleFlag.developer = new RoleFlag("developer", "[black]<[#B000FF]\uE80E[]>[]", "Awarded to people who contribute to the server's codebase.", "[#B000FF]", true, false);
     RoleFlag.member = new RoleFlag("member", "[black]<[yellow]\uE809[]>[]", "Awarded to our awesome donors who support the server.", "[pink]", true, false);
-    RoleFlag.effects = new RoleFlag("effects user", "[black]<[lightgrey]\uE87D,[]>[]", "Assigned to to individuals who have earned access to enhanced visual effect features.", "[lightgrey]", true, true);
+    RoleFlag.illusionist = new RoleFlag("illusionist", "[black]<[lightgrey]\uE87D,[]>[]", "Assigned to to individuals who have earned access to enhanced visual effect features.", "[lightgrey]", true, true);
     return RoleFlag;
 }());
 exports.RoleFlag = RoleFlag;

--- a/build/scripts/ranks.js
+++ b/build/scripts/ranks.js
@@ -73,6 +73,7 @@ var RoleFlag = /** @class */ (function () {
     RoleFlag.flags = {};
     RoleFlag.developer = new RoleFlag("developer", "[black]<[#B000FF]\uE80E[]>[]", "Awarded to people who contribute to the server's codebase.", "[#B000FF]", true, false);
     RoleFlag.member = new RoleFlag("member", "[black]<[yellow]\uE809[]>[]", "Awarded to our awesome donors who support the server.", "[pink]", true, false);
+    RoleFlag.effects = new RoleFlag("effects user", "[black]<[lightgrey]\uE87D,[]>[]", "Assigned to to individuals who have earned access to enhanced visual effect features.", "[lightgrey]", true, true);
     return RoleFlag;
 }());
 exports.RoleFlag = RoleFlag;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -52,7 +52,8 @@ export class Perm {
 	static seeErrorMessages = new Perm("seeErrorMessages", "admin");
 	static viewUUIDs = new Perm("viewUUIDs", "admin");
 	static blockTrolling = new Perm("blockTrolling", fishP => fishP.rank === Rank.pi);
-	static bulkLabelPacket = new Perm("bulkLabelPacket", fishP => ((fishP.hasFlag("developer") || fishP.hasFlag("effects")|| fishP.hasFlag("member")) && !fishP.stelled()) || fishP.ranksAtLeast("mod"));static visualEffects = new Perm("visualEffects", fishP => !fishP.stelled() || fishP.ranksAtLeast("mod"));
+	static bulkLabelPacket = new Perm("bulkLabelPacket", fishP => ((fishP.hasFlag("developer") || fishP.hasFlag("effects")|| fishP.hasFlag("member")) && !fishP.stelled()) || fishP.ranksAtLeast("mod"));
+	static visualEffects = new Perm("visualEffects", fishP => !fishP.stelled() || fishP.ranksAtLeast("mod"));
 	static bypassVoteFreeze = new Perm("bypassVoteFreeze", "trusted");
 	static bypassVotekick = new Perm("bypassVotekick", "mod");
 	static warn = new Perm("warn", "mod");

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -52,7 +52,7 @@ export class Perm {
 	static seeErrorMessages = new Perm("seeErrorMessages", "admin");
 	static viewUUIDs = new Perm("viewUUIDs", "admin");
 	static blockTrolling = new Perm("blockTrolling", fishP => fishP.rank === Rank.pi);
-	static bulkLabelPacket = new Perm("bulkLabelPacket", fishP => ((fishP.hasFlag("developer") || fishP.hasFlag("effects")|| fishP.hasFlag("member")) && !fishP.stelled()) || fishP.ranksAtLeast("mod"));
+	static bulkLabelPacket = new Perm("bulkLabelPacket", fishP => ((fishP.hasFlag("developer") || fishP.hasFlag("illusionist") || fishP.hasFlag("member")) && !fishP.stelled()) || fishP.ranksAtLeast("mod"));
 	static visualEffects = new Perm("visualEffects", fishP => !fishP.stelled() || fishP.ranksAtLeast("mod"));
 	static bypassVoteFreeze = new Perm("bypassVoteFreeze", "trusted");
 	static bypassVotekick = new Perm("bypassVotekick", "mod");

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -52,8 +52,7 @@ export class Perm {
 	static seeErrorMessages = new Perm("seeErrorMessages", "admin");
 	static viewUUIDs = new Perm("viewUUIDs", "admin");
 	static blockTrolling = new Perm("blockTrolling", fishP => fishP.rank === Rank.pi);
-	static bulkLabelPacket = new Perm("bulkLabelPacket", fishP => ((fishP.hasFlag("developer") || fishP.hasFlag("member")) && !fishP.stelled()) || fishP.ranksAtLeast("mod"));
-	static visualEffects = new Perm("visualEffects", fishP => !fishP.stelled() || fishP.ranksAtLeast("mod"));
+	static bulkLabelPacket = new Perm("bulkLabelPacket", fishP => ((fishP.hasFlag("developer") || fishP.hasFlag("effects")|| fishP.hasFlag("member")) && !fishP.stelled()) || fishP.ranksAtLeast("mod"));static visualEffects = new Perm("visualEffects", fishP => !fishP.stelled() || fishP.ranksAtLeast("mod"));
 	static bypassVoteFreeze = new Perm("bypassVoteFreeze", "trusted");
 	static bypassVotekick = new Perm("bypassVotekick", "mod");
 	static warn = new Perm("warn", "mod");

--- a/src/packetHandlers.ts
+++ b/src/packetHandlers.ts
@@ -167,16 +167,16 @@ export const commands = commandList({
 			const outputLines:string[] = [];
 
 			if (lastAccessedLabel && lastLabel) {
-				outputLines.push(`${lastAccessedLabel.name} created label "${lastLabel}".`);
+				outputLines.push(`${lastAccessedLabel.name}[] created label "${lastLabel}".`);
 			}
 			if (lastAccessedBulkLabel) {
-				outputLines.push(`${lastAccessedBulkLabel.name} last used the bulk label effect.`);
+				outputLines.push(`${lastAccessedBulkLabel.name}[] last used the bulk label effect.`);
 			}
 			if (lastAccessedLine) {
-				outputLines.push(`${lastAccessedLine.name} last used the line effect.`);
+				outputLines.push(`${lastAccessedLine.name}[] last used the line effect.`);
 			}
 			if (lastAccessedBulkLine) {
-				outputLines.push(`${lastAccessedBulkLine.name} last used the bulk line effect.`);
+				outputLines.push(`${lastAccessedBulkLine.name}[] last used the bulk line effect.`);
 			}
 
 			output(outputLines.length > 0 ? outputLines.join('\n') : 'No packet handlers have been accessed yet.');

--- a/src/packetHandlers.ts
+++ b/src/packetHandlers.ts
@@ -192,16 +192,16 @@ export const commands = commandList({
 			const outputLines:string[] = [];
 
 			if (lastAccessedLabel && lastLabel) {
-				outputLines.push(`${lastAccessedLabel.name}[] created label "${lastLabel}".`);
+				outputLines.push(`${lastAccessedLabel.name}[white] created label "${lastLabel}".`);
 			}
 			if (lastAccessedBulkLabel) {
-				outputLines.push(`${lastAccessedBulkLabel.name}[] last used the bulk label effect.`);
+				outputLines.push(`${lastAccessedBulkLabel.name}[white] last used the bulk label effect.`);
 			}
 			if (lastAccessedLine) {
-				outputLines.push(`${lastAccessedLine.name}[] last used the line effect.`);
+				outputLines.push(`${lastAccessedLine.name}[white] last used the line effect.`);
 			}
 			if (lastAccessedBulkLine) {
-				outputLines.push(`${lastAccessedBulkLine.name}[] last used the bulk line effect.`);
+				outputLines.push(`${lastAccessedBulkLine.name}[white] last used the bulk line effect.`);
 			}
 
 			output(outputLines.length > 0 ? outputLines.join('\n') : 'No packet handlers have been accessed yet.');
@@ -225,7 +225,7 @@ export const commands = commandList({
 	- Bulk label effect: "bulkLabel", equivalent to multiple label packets, with every label separated by a \'|\' symbol.
 
 [white]Limitations[accent]:
-	- You ${(sender.hasPerm('bulkLabelPacket')?(`[green]have been granted[accent]`):(`[red]do not[accent]`))} have access to bulk effects.
+	- You ${(sender.hasPerm('bulkLabelPacket')?(`[green]have been granted[accent]`):(`[red]do not have[accent]`))} access to bulk effects.
 	- Effects will no longer be drawn at ${MIN_EFFECT_TPS} for server preformance.
 	- Labels cannot last longer than ${MAX_LABEL_TIME} seconds.
 	- There is a set ratelimit for sending packets, be careful ...

--- a/src/packetHandlers.ts
+++ b/src/packetHandlers.ts
@@ -3,7 +3,7 @@ import { FishPlayer } from './players';
 
 //some much needed restrictions
 /** point in which effects will refuse to render */
-const MIN_EFFECT_TPS = 10;
+const MIN_EFFECT_TPS = 20;
 /** maximum duration for user-created labels (seconds) */
 const MAX_LABEL_TIME = 30;
 

--- a/src/ranks.ts
+++ b/src/ranks.ts
@@ -61,6 +61,7 @@ export class RoleFlag {
 	static flags:Record<string, RoleFlag> = {};
 	static developer = new RoleFlag("developer", "[black]<[#B000FF]\uE80E[]>[]", "Awarded to people who contribute to the server's codebase.", "[#B000FF]", true, false);
 	static member = new RoleFlag("member", "[black]<[yellow]\uE809[]>[]", "Awarded to our awesome donors who support the server.", "[pink]", true, false);
+	static effects = new RoleFlag("effects user", "[black]<[lightgrey]\uE87D,[]>[]", "Assigned to to individuals who have earned access to enhanced visual effect features.","[lightgrey]",true, true)
 	//static afk = new RoleFlag("afk", "[orange]\uE876 AFK \uE876 | [white]", "Used for players who are idle for longer than 2 minutes.", "[orange]", false);
 	constructor(
 		public name:string,

--- a/src/ranks.ts
+++ b/src/ranks.ts
@@ -61,7 +61,7 @@ export class RoleFlag {
 	static flags:Record<string, RoleFlag> = {};
 	static developer = new RoleFlag("developer", "[black]<[#B000FF]\uE80E[]>[]", "Awarded to people who contribute to the server's codebase.", "[#B000FF]", true, false);
 	static member = new RoleFlag("member", "[black]<[yellow]\uE809[]>[]", "Awarded to our awesome donors who support the server.", "[pink]", true, false);
-	static effects = new RoleFlag("effects user", "[black]<[lightgrey]\uE87D,[]>[]", "Assigned to to individuals who have earned access to enhanced visual effect features.","[lightgrey]",true, true)
+	static illusionist = new RoleFlag("illusionist", "[black]<[lightgrey]\uE87D,[]>[]", "Assigned to to individuals who have earned access to enhanced visual effect features.","[lightgrey]",true, true)
 	//static afk = new RoleFlag("afk", "[orange]\uE876 AFK \uE876 | [white]", "Used for players who are idle for longer than 2 minutes.", "[orange]", false);
 	constructor(
 		public name:string,


### PR DESCRIPTION
The same concepts as before

- mods+ can assign `effects user` flag to individuals whom they trust will not abuse bulk effects
- `effects user` can use bulkline and bulklabel
- effect-generated labels now have a maximum time limit of 30s
- effects no longer render when servertps < 10
- slight tweaks to `/pkdocs` to be more expansive
- bug fix colors in `/pklast`